### PR TITLE
Run roslyn analyzers as part of the build.

### DIFF
--- a/src/AWSSDK.Extensions.Configuration.SystemsManager/AWSSDK.Extensions.Configuration.SystemsManager.csproj
+++ b/src/AWSSDK.Extensions.Configuration.SystemsManager/AWSSDK.Extensions.Configuration.SystemsManager.csproj
@@ -18,11 +18,18 @@
     <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/aws/aws-dotnet-extensions-configuration/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
+
+    <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.0.*" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" />
   </ItemGroup>
 </Project>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -1,0 +1,12 @@
+<RuleSet Name="RoslynAnalyzer ruleset" ToolsVersion="10.0">
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <!--
+        Suppress verbose warning for nameof() usage.
+        https://github.com/dotnet/roslyn-analyzers/issues/1561
+    -->
+    <Rule Id="CA2208" Action="None" />
+
+    <!-- Raise missing .ConfigureAwait() to a compile time error. -->
+    <Rule Id="CA2007" Action="Error" />
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
## Description
This changes adds roslyn analzyers rules to be run during build.  The ruleset upgrades violation of rule `CA2007: Do not directly await a Task without calling ConfigureAwait` to error and omits warnings for `CA2208: Instantiate argument exceptions correctly`.  The latter is due to workaround cases where `nameof()` is used instead of a static string.  See https://github.com/dotnet/roslyn-analyzers/issues/1561

## Motivation and Context
I would like to ensure code quality & enforce certain rules (such as checking for ConfigureAwait(false) setting).    

## Testing
ran `dotnet build .` in the directory with solutions file.  I get the following error message:

```
SystemsManagerConfigurationProvider.cs(67,38): error CA2007: Do not directly await a Task without calling ConfigureAwait [D:\workspace\private\aws-dotnet-extensions-configuration\src\AWSSDK.Extensions.Configuration.SystemsManager\AWSSDK.Extensions.Configuration.SystemsManager.csproj]
SystemsManagerConfigurationProvider.cs(83,40): error CA2007: Do not directly await a Task without calling ConfigureAwait [D:\workspace\private\aws-dotnet-extensions-configuration\src\AWSSDK.Extensions.Configuration.SystemsManager\AWSSDK.Extensions.Configuration.SystemsManager.csproj]
Internal\SystemsManagerProcessor.cs(39,42): error CA2007: Do not directly await a Task without calling ConfigureAwait [D:\workspace\private\aws-dotnet-extensions-configuration\src\AWSSDK.Extensions.Configuration.SystemsManager\AWSSDK.Extensions.Configuration.SystemsManager.csproj]
```

I didn't plan on addressing the errors as part of this PR.  If you would like me to @KenHundley  , I can do that.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
