### PR TITLE
Added ConfigureAwait(false) to awaited tasks

### DIFF
--- a/src/AWSSDK.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/AWSSDK.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -36,7 +36,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                 string nextToken = null;
                 do
                 {
-                    var response = await client.GetParametersByPathAsync(new GetParametersByPathRequest { Path = path, Recursive = true, WithDecryption = true, NextToken = nextToken });
+                    var response = await client.GetParametersByPathAsync(new GetParametersByPathRequest { Path = path, Recursive = true, WithDecryption = true, NextToken = nextToken }).ConfigureAwait(false);
                     nextToken = response.NextToken;
                     parameters.AddRange(response.Parameters);
                 } while (!string.IsNullOrEmpty(nextToken));

--- a/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -64,7 +64,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                     var cancellationTokenSource = new CancellationTokenSource(source.ReloadAfter.Value);
                     var cancellationChangeToken = new CancellationChangeToken(cancellationTokenSource.Token);
                     return cancellationChangeToken;
-                }, async () => await LoadAsync(true));
+                }, async () => await LoadAsync(true).ConfigureAwait(false));
             }
         }
 
@@ -72,7 +72,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <summary>
         /// Loads the AWS Systems Manager Parameters.
         /// </summary>
-        public override void Load() => LoadAsync(false).GetAwaiter().GetResult();
+        public override void Load() => LoadAsync(false).ConfigureAwait(false).GetAwaiter().GetResult();
 
         private async Task LoadAsync(bool reload)
         {
@@ -80,7 +80,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
             {
                 var path = Source.Path;
                 var awsOptions = Source.AwsOptions;
-                var parameters = await SystemsManagerProcessor.GetParametersByPathAsync(awsOptions, path);
+                var parameters = await SystemsManagerProcessor.GetParametersByPathAsync(awsOptions, path).ConfigureAwait(false);
 
                 Data = ProcessParameters(parameters, path);
 


### PR DESCRIPTION
## Description
I've added `.ConfigureAwait(false)` to all awaited tasks to support potential future use by applications using SynchronizationContext

## Motivation and Context
Needed to help prevent deadlocks when SynchronizationContext is used

## Testing
Tests were not affected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
