### PR TITLE
remove secretsmanager reference from systems manager processor

### DIFF
--- a/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class SystemsManagerExtensions
     {
-        private const string SecretsManagerPath = "/aws/reference/secretsmanager/";
-        private const string SecretsManagerExceptionMessage = "Secrets Manager paths are not supported";
-
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager Parameter Store with a specified path.
         /// </summary>
@@ -89,7 +86,6 @@ namespace Microsoft.Extensions.Configuration
             configureSource(source);
 
             if (string.IsNullOrWhiteSpace(source.Path)) throw new ArgumentNullException(nameof(source.Path));
-            if (source.Path.StartsWith(SecretsManagerPath, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException(SecretsManagerExceptionMessage);
             if (source.AwsOptions != null) return builder.Add(source);
             
             var config = builder.Build();

--- a/test/AWSSDK.Extensions.Configuration.SystemsManagerTests/SystemsManagerExtensionsTests.cs
+++ b/test/AWSSDK.Extensions.Configuration.SystemsManagerTests/SystemsManagerExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace AWSSDK.Extensions.Configuration.SystemsManagerTests
             if (exceptionType != null)
             {
                 var ex = Assert.Throws(exceptionType, ExecuteBuilder);
-                Assert.Equal(exceptionMessage, ex.Message);
+                Assert.Equal(exceptionMessage, ex.Message.Replace("\r","", StringComparison.InvariantCultureIgnoreCase));
             }
             else
             {
@@ -45,7 +45,7 @@ namespace AWSSDK.Extensions.Configuration.SystemsManagerTests
             if (exceptionType != null)
             {
                 var ex = Assert.Throws(exceptionType, ExecuteBuilder);
-                Assert.Equal(exceptionMessage, ex.Message);
+                Assert.Equal(exceptionMessage, ex.Message.Replace("\r","", StringComparison.InvariantCultureIgnoreCase));
             }
             else
             {
@@ -64,7 +64,7 @@ namespace AWSSDK.Extensions.Configuration.SystemsManagerTests
             if (exceptionType != null)
             {
                 var ex = Assert.Throws(exceptionType, ExecuteBuilder);
-                Assert.Equal(exceptionMessage, ex.Message);
+                Assert.Equal(exceptionMessage, ex.Message.Replace("\r","", StringComparison.InvariantCultureIgnoreCase));
             }
             else
             {
@@ -76,29 +76,25 @@ namespace AWSSDK.Extensions.Configuration.SystemsManagerTests
         public static TheoryData<AWSOptions, string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string> SourceExtensionData =>
             new TheoryData<AWSOptions, string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string>
             {
-                {null, null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: Path"},
-                {null, null, true, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: Path"},
+                {null, null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: Path"},
+                {null, null, true, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: Path"},
                 {null, "/path", false, null, null, null, null},
-                {null, "/aws/reference/secretsmanager/somevalue", false, null, null, typeof(ArgumentException), "Secrets Manager paths are not supported"}
             };
 
         public static TheoryData<AWSOptions, string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string> WithAWSOptionsExtensionData =>
             new TheoryData<AWSOptions, string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string>
             {
-                {null, null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: awsOptions"},
-                {null, "/path", false, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: awsOptions"},
-                {new AWSOptions(), null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: Path"},
+                {null, null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: awsOptions"},
+                {null, "/path", false, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: awsOptions"},
+                {new AWSOptions(), null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: Path"},
                 {new AWSOptions(), "/path", false, null, null, null, null},
-                {new AWSOptions(), "/aws/reference/secretsmanager/somevalue", false, null, null, typeof(ArgumentException), "Secrets Manager paths are not supported"}
-
             };
 
         public static TheoryData<string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string> NoAWSOptionsExtensionData =>
             new TheoryData<string, bool, TimeSpan?, Action<SystemsManagerExceptionContext>, Type, string>
             {
-                {null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\r\nParameter name: Path"},
+                {null, false, null, null, typeof(ArgumentNullException), "Value cannot be null.\nParameter name: Path"},
                 {"/path", false, null, null, null, null},
-                {"/aws/reference/secretsmanager/somevalue", false, null, null, typeof(ArgumentException), "Secrets Manager paths are not supported"}
             };
     }
 }


### PR DESCRIPTION
## Description
Parameter store rejects parameters with prefix "aws".  Also, considering the previous PR discussion, as we are planning on adding a separate secretsmanager extension, these few lines seemed out of place.

Also, updated tests to handle carriage returns.  The unit tests fail on Mac.

## Testing
Ran unit tests on Mac, it passes!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
