### PR TITLE
Limiting "var config = builder.Build();" to only be run once.

### DIFF
--- a/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/AWSSDK.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
-                builder.Properties.Add(AwsOptionsConfigurationKey, newOptions);    
+                builder.Properties.Add(AwsOptionsConfigurationKey, newOptions);
             }
 
             return newOptions;


### PR DESCRIPTION
## Description
While creating the sample project I noticed some unintended side effects of calling the following lines more than once.
```csharp
var config = builder.Build();
source.AwsOptions = config.GetAWSOptions();
```

This was happening when you added multiple instances of `AddSystemsManager` while not directly supplying an `AWSOptions` instance. 

__What was happening:__
Each subsequent call to `AddSystemsManager` was invoking all of the `AddSystemsManager` calls that were already created above it. Causing it to create many more providers than intended.
`AddSystemsManager` x1 = 1 provider created
`AddSystemsManager` x2 = 3
`AddSystemsManager` x3 = 6
`AddSystemsManager` x4 = 10

After this change the `builder.Build();` will only be called once and the created instance of `AWSOptions` will be shared with all subsequent calls.
`AddSystemsManager` x3 = 3 providers created

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
