### PR TITLE
Add extension method to IConfiguration to wait for reload

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -227,3 +227,42 @@ namespace Microsoft.Extensions.Configuration
         }
     }
 }
+
+namespace Amazon.Extensions.Configuration.SystemsManager
+{
+    using Microsoft.Extensions.Configuration;
+
+    /// <summary>
+    /// This extension is an a different namespace to avoid misuse of this method which should only be called when being used from Lambda.
+    /// </summary>
+    public static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// This method blocks while any SystemsManagerConfigurationProvider added to IConfiguration are
+        /// currently reloading the parameters from Parameter Store.
+        /// 
+        /// This is generally only needed when the provider is being called from a Lambda function. Without this call
+        /// in a Lambda environment there is a potential of the background thread doing the refresh never running successfully.
+        /// This can happen because the Lambda compute environment is frozen after the current Lambda event is complete.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="timeSpan"></param>
+        public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeSpan)
+        {
+            var configRoot = configuration as ConfigurationRoot;
+            if(configRoot == null)
+            {
+                return;
+            }
+
+            foreach(var provider in configRoot.Providers)
+            {
+                if(provider is SystemsManagerConfigurationProvider ssmProvider)
+                {
+                    ssmProvider.WaitForReloadToComplete(timeSpan);
+                }
+            }
+        }
+    }
+
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurationBuilderIntegrationTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurationBuilderIntegrationTests.cs
@@ -38,6 +38,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Integ
             Assert.All(fixture.TestData, (pair) => {
                 Assert.Equal(pair.Value, configurations[pair.Key]);
             });
+
+            // Since there is no reload going on this should return back immediately.
+            configurations.WaitForSystemsManagerReloadToComplete(TimeSpan.FromHours(1));
         }
 
         [Fact]


### PR DESCRIPTION
This new extension method can be used in Lambda functions to ensure any reloads from Parameter Store are completed before the Lambda function exits.

## Description
New extension method for `IConfiguration` called `WaitForSystemsManagerReloadToComplete`. This extension method is not in `IConfiguration` namespace and instead in `Amazon.Extensions.Configuration.SystemsManager` to avoid misuse of this method.

## Motivation and Context
Help developers using this library in Lambda functions which could potentially not be able to reload configuration because the Lambda compute environment is frozen after processing the Lambda event.


