### PR TITLE
Added Secrets Manager path support

### DIFF
--- a/samples/Samples.sln
+++ b/samples/Samples.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.28010.2048
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Extensions.Configuration.SystemsManager", "..\src\Amazon.Extensions.Configuration.SystemsManager\Amazon.Extensions.Configuration.SystemsManager.csproj", "{CE965321-158B-47C8-BDA3-748F18745532}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "Samples\Samples.csproj", "{74F8A828-62EB-4338-A106-F28D91FE4B3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples", "Samples\Samples.csproj", "{74F8A828-62EB-4338-A106-F28D91FE4B3A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>
@@ -46,6 +46,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.0.*" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -43,8 +43,8 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.0.*" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.10.*" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.*" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.100.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.*" />
   </ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
@@ -35,13 +35,14 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <param name="timeSpan"></param>
         public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeSpan)
         {
-            if(!(configuration is ConfigurationRoot configRoot)) return;
-
-            foreach(var provider in configRoot.Providers)
+            if (configuration is ConfigurationRoot configRoot)
             {
-                if(provider is SystemsManagerConfigurationProvider ssmProvider)
+                foreach (var provider in configRoot.Providers)
                 {
-                    ssmProvider.WaitForReloadToComplete(timeSpan);
+                    if (provider is SystemsManagerConfigurationProvider ssmProvider)
+                    {
+                        ssmProvider.WaitForReloadToComplete(timeSpan);
+                    }
                 }
             }
         }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Amazon.Extensions.Configuration.SystemsManager
+{
+    /// <summary>
+    /// This extension is an a different namespace to avoid misuse of this method which should only be called when being used from Lambda.
+    /// </summary>
+    public static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// This method blocks while any SystemsManagerConfigurationProvider added to IConfiguration are
+        /// currently reloading the parameters from Parameter Store.
+        /// 
+        /// This is generally only needed when the provider is being called from a Lambda function. Without this call
+        /// in a Lambda environment there is a potential of the background thread doing the refresh never running successfully.
+        /// This can happen because the Lambda compute environment is frozen after the current Lambda event is complete.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="timeSpan"></param>
+        public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeSpan)
+        {
+            if(!(configuration is ConfigurationRoot configRoot)) return;
+
+            foreach(var provider in configRoot.Providers)
+            {
+                if(provider is SystemsManagerConfigurationProvider ssmProvider)
+                {
+                    ssmProvider.WaitForReloadToComplete(timeSpan);
+                }
+            }
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
@@ -34,6 +34,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager
             return parameter.Name.Substring(path.Length).TrimStart('/').Replace("/", KeyDelimiter);
         }
 
-        public string GetValue(Parameter parameter, string path) => parameter.Value;
+        public virtual string GetValue(Parameter parameter, string path) => parameter.Value;
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/DictionaryExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/DictionaryExtensions.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Internal
+{
+    public static class DictionaryExtensions
+    {
+        public static bool DictionaryEqual<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second) => DictionaryEqual(first, second, null);
+
+        public static bool DictionaryEqual<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second, IEqualityComparer<TValue> valueComparer)
+        {
+            if (first == second) return true;
+            if (first == null || second == null) return false;
+            if (first.Count != second.Count) return false;
+
+            valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+
+            foreach (var kvp in first)
+            {
+                if (!second.TryGetValue(kvp.Key, out var secondValue)) return false;
+                if (!valueComparer.Equals(kvp.Value, secondValue)) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/DictionaryExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/DictionaryExtensions.cs
@@ -19,9 +19,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
 {
     public static class DictionaryExtensions
     {
-        public static bool DictionaryEqual<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second) => DictionaryEqual(first, second, null);
+        public static bool EquivalentTo<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second) => EquivalentTo(first, second, null);
 
-        public static bool DictionaryEqual<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second, IEqualityComparer<TValue> valueComparer)
+        public static bool EquivalentTo<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second, IEqualityComparer<TValue> valueComparer)
         {
             if (first == second) return true;
             if (first == null || second == null) return false;

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
@@ -1,0 +1,159 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Internal
+{
+    public class JsonConfigurationParser : IDisposable
+    {
+        private JsonConfigurationParser() { }
+
+        private readonly IDictionary<string, string> _data = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Stack<string> _context = new Stack<string>();
+        private string _currentPath;
+
+        private JsonTextReader _reader;
+
+        public static IDictionary<string, string> Parse(Stream input)
+        {
+            using (var reader = new StreamReader(input))
+            using (var parser = new JsonConfigurationParser())
+            {
+                return parser.ParseInput(reader);    
+            }
+        }
+
+        public static IDictionary<string, string> Parse(string input)
+        {
+            using (var reader = new StringReader(input))
+            using (var parser = new JsonConfigurationParser())
+            {
+                return parser.ParseInput(reader);    
+            }
+        }
+
+        private IDictionary<string, string> ParseInput(TextReader input)
+        {
+            _data.Clear();
+            using (_reader = new JsonTextReader(input) {DateParseHandling = DateParseHandling.None})
+            {
+                var jsonConfig = JObject.Load(_reader);
+
+                VisitJObject(jsonConfig);
+
+                return _data;
+            }
+        }
+        
+        private void VisitJObject(JObject jObject)
+        {
+            foreach (var property in jObject.Properties())
+            {
+                EnterContext(property.Name);
+                VisitProperty(property);
+                ExitContext();
+            }
+        }
+
+        private void VisitProperty(JProperty property)
+        {
+            VisitToken(property.Value);
+        }
+
+        private void VisitToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    VisitJObject(token.Value<JObject>());
+                    break;
+
+                case JTokenType.Array:
+                    VisitArray(token.Value<JArray>());
+                    break;
+
+                case JTokenType.Integer:
+                case JTokenType.Float:
+                case JTokenType.String:
+                case JTokenType.Boolean:
+                case JTokenType.Bytes:
+                case JTokenType.Raw:
+                case JTokenType.Null:
+                    VisitPrimitive(token.Value<JValue>());
+                    break;
+
+                default:
+                    throw new FormatException($"Unsupported JSON token '{_reader.TokenType}' was found. SecretId '{_reader.Path}', line {_reader.LineNumber} position {_reader.LinePosition}.");
+            }
+        }
+
+        private void VisitArray(JArray array)
+        {
+            for (var index = 0; index < array.Count; index++)
+            {
+                EnterContext(index.ToString(CultureInfo.InvariantCulture));
+                VisitToken(array[index]);
+                ExitContext();
+            }
+        }
+
+        private void VisitPrimitive(JValue data)
+        {
+            var key = _currentPath;
+
+            if (_data.ContainsKey(key))
+            {
+                throw new FormatException($"A duplicate key '{key}' was found.");
+            }
+
+            _data[key] = data.Value == null ? null : data.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private void EnterContext(string context)
+        {
+            _context.Push(context);
+            _currentPath = ConfigurationPath.Combine(_context.Reverse());
+        }
+
+        private void ExitContext()
+        {
+            _context.Pop();
+            _currentPath = ConfigurationPath.Combine(_context.Reverse());
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ((IDisposable) _reader)?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -35,9 +35,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
         private const string SecretsManagerPath = "/aws/reference/secretsmanager/";
 
         private SystemsManagerConfigurationSource Source { get; }
+        private Func<IEnumerable<Parameter>, string, IParameterProcessor, IDictionary<string, string>> ProcessParameters { get; }
 
-        public SystemsManagerProcessor(SystemsManagerConfigurationSource source)
+        public SystemsManagerProcessor(SystemsManagerConfigurationSource source, Func<IEnumerable<Parameter>, string, IParameterProcessor, IDictionary<string, string>> processParameters)
         {
+            ProcessParameters = processParameters;
             Source = source;
             Source.ParameterProcessor = Source.ParameterProcessor ?? new DefaultParameterProcessor();
         }
@@ -86,7 +88,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                 
                 var prefix = Source.Prefix ?? Source.ParameterProcessor.GetKey(response.Parameter, SecretsManagerPath);
                 return AddPrefix(JsonConfigurationParser.Parse(Source.ParameterProcessor.GetValue(response.Parameter, SecretsManagerPath)), prefix);
-
             }
         }
 
@@ -97,18 +98,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
             return string.IsNullOrEmpty(prefix)
                 ? input
                 : input.ToDictionary(pair => $"{prefix}{ConfigurationPath.KeyDelimiter}{pair.Key}", pair => pair.Value, StringComparer.OrdinalIgnoreCase);
-        }
-
-        public static IDictionary<string, string> ProcessParameters(IEnumerable<Parameter> parameters, string path, IParameterProcessor parameterProcessor)
-        {
-            return parameters
-                .Where(parameter => parameterProcessor.IncludeParameter(parameter, path))
-                .Select(parameter => new
-                {
-                    Key = parameterProcessor.GetKey(parameter, path),
-                    Value = parameterProcessor.GetValue(parameter, path)
-                })
-                .ToDictionary(parameter => parameter.Key, parameter => parameter.Value, StringComparer.OrdinalIgnoreCase);
         }
 
         private const string UserAgentHeader = "User-Agent";

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -99,7 +99,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                 : input.ToDictionary(pair => $"{prefix}{ConfigurationPath.KeyDelimiter}{pair.Key}", pair => pair.Value, StringComparer.OrdinalIgnoreCase);
         }
 
-
         public static IDictionary<string, string> ProcessParameters(IEnumerable<Parameter> parameters, string path, IParameterProcessor parameterProcessor)
         {
             return parameters

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -113,7 +113,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
 
                 var newData = ProcessParameters(parameters, path);
 
-                if (!DictionaryEqual(Data, newData))
+                if (!Data.DictionaryEqual(newData))
                 {
                     Data = newData;
 
@@ -148,26 +148,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                 .Select(parameter => new
                 {
                     Key = ParameterProcessor.GetKey(parameter, path),
-                    Value = ParameterProcessor.GetValue(parameter, path),
+                    Value = ParameterProcessor.GetValue(parameter, path)
                 })
                 .ToDictionary(parameter => parameter.Key, parameter => parameter.Value, StringComparer.OrdinalIgnoreCase);
-
-        private static bool DictionaryEqual<TKey, TValue>(IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second) => DictionaryEqual(first, second, null);
-
-        private static bool DictionaryEqual<TKey, TValue>(IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second, IEqualityComparer<TValue> valueComparer)
-        {
-            if (first == second) return true;
-            if (first == null || second == null) return false;
-            if (first.Count != second.Count) return false;
-
-            valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
-
-            foreach (var kvp in first)
-            {
-                if (!second.TryGetValue(kvp.Key, out var secondValue)) return false;
-                if (!valueComparer.Equals(kvp.Value, secondValue)) return false;
-            }
-            return true;
-        }
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -113,7 +113,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
 
                 var newData = ProcessParameters(parameters, path);
 
-                if (!Data.DictionaryEqual(newData))
+                if (!Data.EquivalentTo(newData))
                 {
                     Data = newData;
 

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -41,7 +41,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// Initializes a new instance with the specified source.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> used to retrieve values from AWS Systems Manager Parameter Store</param>
-        public SystemsManagerConfigurationProvider(SystemsManagerConfigurationSource source) : this(source, new SystemsManagerProcessor(source, ProcessParameters))
+        public SystemsManagerConfigurationProvider(SystemsManagerConfigurationSource source) : this(source, new SystemsManagerProcessor(source))
         {
         }
 
@@ -137,6 +137,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
             }
         }
 
+        [Obsolete("This method has been moved into the internal namespace, and will be removed in a future release. Use ParameterProcessor instead")]
         public static IDictionary<string, string> ProcessParameters(IEnumerable<Parameter> parameters, string path, IParameterProcessor parameterProcessor)
         {
             return parameters

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
@@ -47,6 +47,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         public TimeSpan? ReloadAfter { get; set; }
 
         /// <summary>
+        /// Prepends the supplied Prefix to all result keys
+        /// </summary>
+        public string Prefix { get; set; }
+        
+        /// <summary>
         /// Will be called if an uncaught exception occurs in <see cref="SystemsManagerConfigurationProvider"/>.Load.
         /// </summary>
         public Action<SystemsManagerExceptionContext> OnLoadException { get; set; }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class SystemsManagerExtensions
     {
-        private const string SecretsManagerPath = "/aws/reference/secretsmanager/";
-        private const string SecretsManagerExceptionMessage = "Secrets Manager paths are not supported";
         private const string AwsOptionsConfigurationKey = "AWS_CONFIGBUILDER_AWSOPTIONS";
 
         /// <summary>
@@ -186,7 +184,6 @@ namespace Microsoft.Extensions.Configuration
             configureSource(source);
 
             if (string.IsNullOrWhiteSpace(source.Path)) throw new ArgumentNullException(nameof(source.Path));
-            if (source.Path.StartsWith(SecretsManagerPath, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException(SecretsManagerExceptionMessage);
             if (source.AwsOptions != null) return builder.Add(source);
 
             source.AwsOptions = builder.GetAwsOptions();
@@ -226,43 +223,4 @@ namespace Microsoft.Extensions.Configuration
             return newOptions;
         }
     }
-}
-
-namespace Amazon.Extensions.Configuration.SystemsManager
-{
-    using Microsoft.Extensions.Configuration;
-
-    /// <summary>
-    /// This extension is an a different namespace to avoid misuse of this method which should only be called when being used from Lambda.
-    /// </summary>
-    public static class ConfigurationExtensions
-    {
-        /// <summary>
-        /// This method blocks while any SystemsManagerConfigurationProvider added to IConfiguration are
-        /// currently reloading the parameters from Parameter Store.
-        /// 
-        /// This is generally only needed when the provider is being called from a Lambda function. Without this call
-        /// in a Lambda environment there is a potential of the background thread doing the refresh never running successfully.
-        /// This can happen because the Lambda compute environment is frozen after the current Lambda event is complete.
-        /// </summary>
-        /// <param name="configuration"></param>
-        /// <param name="timeSpan"></param>
-        public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeSpan)
-        {
-            var configRoot = configuration as ConfigurationRoot;
-            if(configRoot == null)
-            {
-                return;
-            }
-
-            foreach(var provider in configRoot.Providers)
-            {
-                if(provider is SystemsManagerConfigurationProvider ssmProvider)
-                {
-                    ssmProvider.WaitForReloadToComplete(timeSpan);
-                }
-            }
-        }
-    }
-
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurationBuilderIntegrationTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurationBuilderIntegrationTests.cs
@@ -42,13 +42,5 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Integ
             // Since there is no reload going on this should return back immediately.
             configurations.WaitForSystemsManagerReloadToComplete(TimeSpan.FromHours(1));
         }
-
-        [Fact]
-        public void TestInvalidPrefix()
-        {
-            var configurationBuilder = new ConfigurationBuilder();
-            Exception ex = Assert.Throws<ArgumentException>(() => configurationBuilder.AddSystemsManager(@"/aws/reference/secretsmanager/hello", fixture.AWSOptions));
-            Assert.Equal("Secrets Manager paths are not supported", ex.Message);
-        }
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurtaionBuilderIntegrationTestFixture.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/ConfigurtaionBuilderIntegrationTestFixture.cs
@@ -28,7 +28,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Integ
     {
         public const string ParameterPrefix = @"/configuration-extension-testdata/ssm/";
 
-        public AWSOptions AWSOptions { get; private set; }        
+        public AWSOptions AWSOptions { get; private set; }
 
         private bool disposed = false;
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
@@ -13,10 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DictionaryExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DictionaryExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class DictionaryExtensionsTests
+    {
+        [Theory]
+        [MemberData(nameof(DictionaryEqualsData))]
+        public void TestDictionaryEquals(IDictionary<string, string> first, IDictionary<string, string> second, bool equals)
+        {
+            Assert.Equal(equals, first.DictionaryEqual(second));
+        }
+
+        public static TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool> DictionaryEqualsData => new TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool>
+        {
+            {new Dictionary<string, string>(), new Dictionary<string, string>(), true},
+            {new Dictionary<string, string>(), null, false},
+            {new Dictionary<string, string>(), new Dictionary<string, string> {{"a", "a"}}, false},
+            {new Dictionary<string, string> {{"a", "a"}}, new Dictionary<string, string> {{"a", "a"}}, true},
+            {new Dictionary<string, string> {{"a", "a"}}, new Dictionary<string, string> {{"a", "a"}, {"b", "b"}}, false},
+            {new Dictionary<string, string> {{"a", "a"}}, new Dictionary<string, string> {{"b", "b"}}, false},
+            {new Dictionary<string, string> {{"a", "a"}}, new Dictionary<string, string> {{"a", "b"}}, false},
+            {new Dictionary<string, string> {{"a", "a"}}, new Dictionary<string, string> {{"b", "a"}}, false},
+            {new Dictionary<string, string> {{"a", "a"},{"b", "b"}}, new Dictionary<string, string> {{"b", "b"},{"a", "a"}}, true}
+        };
+    }
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DictionaryExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DictionaryExtensionsTests.cs
@@ -7,13 +7,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
     public class DictionaryExtensionsTests
     {
         [Theory]
-        [MemberData(nameof(DictionaryEqualsData))]
-        public void TestDictionaryEquals(IDictionary<string, string> first, IDictionary<string, string> second, bool equals)
+        [MemberData(nameof(EquivalentToData))]
+        public void TestEquivalentTo(IDictionary<string, string> first, IDictionary<string, string> second, bool equals)
         {
-            Assert.Equal(equals, first.DictionaryEqual(second));
+            Assert.Equal(equals, first.EquivalentTo(second));
         }
 
-        public static TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool> DictionaryEqualsData => new TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool>
+        public static TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool> EquivalentToData => new TheoryData<IDictionary<string, string>, IDictionary<string, string>, bool>
         {
             {new Dictionary<string, string>(), new Dictionary<string, string>(), true},
             {new Dictionary<string, string>(), null, false},

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -47,7 +47,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             _source = new SystemsManagerConfigurationSource
             {
                 ParameterProcessor = _parameterProcessorMock.Object,
-                AwsOptions = new AWSOptions(), 
+                AwsOptions = new AWSOptions(),
                 Path = Path
             };
             _provider = new SystemsManagerConfigurationProvider(_source, _systemsManagerProcessorMock.Object);
@@ -64,7 +64,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             }
 
             var data = _provider.ProcessParameters(_parameters, Path);
-            
+
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
 
             _parameterProcessorMock.VerifyAll();
@@ -79,7 +79,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
                 _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
             }
-            
+
             _provider.Load();
 
             foreach (var parameter in _parameters)

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -60,7 +60,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
             }
 
-            var getData = SystemsManagerConfigurationProvider.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var getData = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
 
             _systemsManagerProcessorMock.Setup(p => p.GetDataAsync()).ReturnsAsync(() => getData);
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -60,7 +60,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
             }
 
-            var getData = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var getData = SystemsManagerConfigurationProvider.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
 
             _systemsManagerProcessorMock.Setup(p => p.GetDataAsync()).ReturnsAsync(() => getData);
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationSourceTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationSourceTests.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-using Amazon.Extensions.Configuration.SystemsManager;
 using Amazon.Extensions.NETCore.Setup;
 using Microsoft.Extensions.Configuration;
 using Xunit;

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerExtensionsTests.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 using System;
-using Amazon.Extensions.Configuration.SystemsManager;
 using Amazon.Extensions.NETCore.Setup;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -49,7 +48,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             {builder => builder.AddSystemsManager(CreateSource(null, null, false, null, null)), typeof(ArgumentNullException), "Parameter name: Path"},
             {builder => builder.AddSystemsManager(CreateSource(null, null, true, null, null)), typeof(ArgumentNullException), "Parameter name: Path"},
             {builder => builder.AddSystemsManager(CreateSource("/path", null, false, null, null)), null, null},
-            {builder => builder.AddSystemsManager(CreateSource("/aws/reference/secretsmanager/somevalue", null, false, null, null)), typeof(ArgumentException), "Secrets Manager paths are not supported"}
+            {builder => builder.AddSystemsManager(CreateSource("/aws/reference/secretsmanager/somevalue", null, false, null, null)), null, null}
         };
 
         public static TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string> WithAWSOptionsExtensionData => new TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string>
@@ -57,7 +56,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             {builder => builder.AddSystemsManager(null, null), typeof(ArgumentNullException), "Parameter name: path"},
             {builder => builder.AddSystemsManager("/path", null), typeof(ArgumentNullException), "Parameter name: awsOptions"},
             {builder => builder.AddSystemsManager(null, new AWSOptions()), typeof(ArgumentNullException), "Parameter name: path"},
-            {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue", new AWSOptions()), typeof(ArgumentException), "Secrets Manager paths are not supported"},
+            {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue", new AWSOptions()), null, null},
             {builder => builder.AddSystemsManager("/path", new AWSOptions(), true), null, null},
             {builder => builder.AddSystemsManager("/path", new AWSOptions(), false), null, null},
             {builder => builder.AddSystemsManager("/path", new AWSOptions(), TimeSpan.Zero), null, null},
@@ -70,7 +69,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             {builder => builder.AddSystemsManager(null as string), typeof(ArgumentNullException), "Parameter name: path"},
             {builder => builder.AddSystemsManager("/path"), null, null},
-            {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue"), typeof(ArgumentException), "Secrets Manager paths are not supported"},
+            {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue"), null, null},
             {builder => builder.AddSystemsManager("/path", true), null, null},
             {builder => builder.AddSystemsManager("/path", false), null, null},
             {builder => builder.AddSystemsManager("/path", TimeSpan.Zero), null, null},

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -36,7 +36,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, Path)).Returns(parameter.Value);
             }
 
-            var data = SystemsManagerConfigurationProvider.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var data = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
 
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -36,7 +36,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, Path)).Returns(parameter.Value);
             }
 
-            var data = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var data = SystemsManagerConfigurationProvider.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
 
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
 

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
+using Amazon.SimpleSystemsManagement.Model;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class SystemsManagerProcessorTests
+    {
+        private readonly List<Parameter> _parameters = new List<Parameter>
+        {
+            new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
+            new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
+            new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
+            new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"}
+        };
+
+        private const string Path = "/start/path";
+
+        private readonly Mock<IParameterProcessor> _parameterProcessorMock;
+
+        public SystemsManagerProcessorTests()
+        {
+            _parameterProcessorMock = new Mock<IParameterProcessor>();
+        }
+
+        [Fact]
+        public void ProcessParametersTest()
+        {
+            foreach (var parameter in _parameters)
+            {
+                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
+                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, Path)).Returns(parameter.Value);
+            }
+
+            var data = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+
+            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
+
+            _parameterProcessorMock.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData("/aws/reference/secretsmanager/", true)]
+        [InlineData("/not-sm-path/", false)]
+        public void IsSecretsManagerPathTest(string path, bool expected)
+        {
+            Assert.Equal(expected, SystemsManagerProcessor.IsSecretsManagerPath(path));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("prefix")]
+        public void AddPrefixTest(string prefix)
+        {
+            var data = new Dictionary<string, string> {{"Key", "Value"}};
+            var output = SystemsManagerProcessor.AddPrefix(data, prefix);
+
+            if (prefix == null)
+            {
+                Assert.Equal(data, output);
+            }
+            else
+            {
+                foreach (var item in output)
+                {
+                    Assert.StartsWith($"{prefix}:", item.Key);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
I've added the ability to support keys with a Secrets Manager prefix. The processor will now detect if a path is a Secrets Manager path and switch to the GetParameter call. 

I've also added a `Prefix` property to the configuration source object. If no prefix is supplied then the name of the secret will become the root name in the configuration key. I knew there would likely be situations where the secret name would not work correctly as a key or would not be the desired name, so with the prefix the user can substituted it for the secret name. 

This prefix also works with the original implementation. If you supply the prefix property it'll prepend the prefix to the returned keys, allowing you to group the results under a desired root. There is no change to the original behavior, just additional options.

NOTE: This PR includes the same changes in #29 

## Motivation and Context
I have a project that needs to read a vendors username and password from a custom Secret rotation. This allows me to do that without affecting the original implementation. I was originally going to create a new `AddSecretsManager` implementation, but I realized this was a much simpler approach while accomplishing getting the same result.

The only thing not available from SecretsManager through this implementation is the use of the `SecretBinary` structure. However, this limitation is because the Param Store implementation itself doesn't support it and only supports the `SecretString` value. 

## Testing
I added unit tests for the changes and new code. I also tested the implemention through the sample project, however, I did not add this to the same project as SecretsManager has costs associated with it, and requires 7 days or more to delete from an account.

I also tested this with including the stage and version:
`/aws/reference/secretsmanager/master-database`
`/aws/reference/secretsmanager/master-database:AWSCURRENT`
`/aws/reference/secretsmanager/master-database:4adda750-7e7f-47e7-8224-e6bd3f7387ea`

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/2495780/53705823-13cd1500-3df5-11e9-96b0-aed3b3a1b4e7.png)

Mapping:
![image](https://user-images.githubusercontent.com/2495780/53712457-ee500380-3e14-11e9-8381-0a76f236365b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
