### PR TITLE
Prevents stripping the first char when the Path is "/"

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System;
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
 
@@ -31,7 +32,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager
 
         public virtual string GetKey(Parameter parameter, string path)
         {
-            return parameter.Name.Substring(path.Length).TrimStart('/').Replace("/", KeyDelimiter);
+            var name = parameter.Name.StartsWith(path, StringComparison.OrdinalIgnoreCase) 
+                ? parameter.Name.Substring(path.Length) 
+                : parameter.Name;
+            return name.TrimStart('/').Replace("/", KeyDelimiter);
         }
 
         public virtual string GetValue(Parameter parameter, string path) => parameter.Value;

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -9,16 +9,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 {
     public class SystemsManagerProcessorTests
     {
-        private readonly List<Parameter> _parameters = new List<Parameter>
-        {
-            new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
-            new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
-            new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
-            new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"}
-        };
-
-        private const string Path = "/start/path";
-
         private readonly Mock<IParameterProcessor> _parameterProcessorMock;
 
         public SystemsManagerProcessorTests()
@@ -29,14 +19,49 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         [Fact]
         public void ProcessParametersTest()
         {
-            foreach (var parameter in _parameters)
+            var parameters = new List<Parameter>
             {
-                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
-                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, Path)).Returns(parameter.Value);
+                new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
+                new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
+                new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
+                new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"},
+            };
+
+            const string path = "/start/path";
+
+            foreach (var parameter in parameters)
+            {
+                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
+                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
             }
 
-            var data = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);
+
+            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
+
+            _parameterProcessorMock.VerifyAll();
+        }
+
+        [Fact]
+        public void ProcessParametersRootTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/p1", Value = "p1"},
+                new Parameter {Name = "p2", Value = "p2"},
+            };
+
+            const string path = "/";
+
+            foreach (var parameter in parameters)
+            {
+                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
+                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
+            }
+
+            var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);
 
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
 
@@ -56,7 +81,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         [InlineData("prefix")]
         public void AddPrefixTest(string prefix)
         {
-            var data = new Dictionary<string, string> {{"Key", "Value"}};
+            var data = new Dictionary<string, string> { { "Key", "Value" } };
             var output = SystemsManagerProcessor.AddPrefix(data, prefix);
 
             if (prefix == null)


### PR DESCRIPTION
This update prevents stripping the first character from parameters when the path is `/`.

A path of `/` is a special case where the SSM Param Store returns all parameters, even if they don't actually start with `/`. Previouly the code expected all results to begin with the path specified and removed that path before processing, but in the case of `/` not all results will start with `/`

This is related to #40 

## Testing
All existing tests passed and added new test for path = `/`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
