### PR TITLE
Added  `Filters` property to SystemsManagerConfigurationSource 

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -62,32 +62,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                 string nextToken = null;
                 do
                 {
-                    var response = await client.GetParametersByPathAsync(new GetParametersByPathRequest
-                    {
-                        Path = Source.Path,
-                        Recursive = true,
-                        WithDecryption = true,
-                        NextToken = nextToken,
-                        ParameterFilters = CreateLabelFilter(Source.Label)
-                    }).ConfigureAwait(false);
+                    var response = await client.GetParametersByPathAsync(new GetParametersByPathRequest { Path = Source.Path, Recursive = true, WithDecryption = true, NextToken = nextToken, ParameterFilters = Source.Filters }).ConfigureAwait(false);
                     nextToken = response.NextToken;
                     parameters.AddRange(response.Parameters);
                 } while (!string.IsNullOrEmpty(nextToken));
 
                 return AddPrefix(ProcessParameters(parameters, Source.Path, Source.ParameterProcessor), Source.Prefix);
             }
-        }
-
-        public static List<ParameterStringFilter> CreateLabelFilter(string label)
-        {
-            if (string.IsNullOrWhiteSpace(label))
-                return null;
-            return new List<ParameterStringFilter> { new ParameterStringFilter
-            {
-                Key="Label",
-                Option="Equals",
-                Values = new List<string>{label}
-            }};
         }
 
         private async Task<IDictionary<string, string>> GetParameterAsync()

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Amazon.Extensions.NETCore.Setup;
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager
     /// </summary>
     public class SystemsManagerConfigurationSource : IConfigurationSource
     {
+        public SystemsManagerConfigurationSource()
+        {
+            Filters = new List<ParameterStringFilter>();
+        }
+
         /// <summary>
         /// A Path used to filter parameters.
         /// </summary>
@@ -50,7 +56,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// Prepends the supplied Prefix to all result keys
         /// </summary>
         public string Prefix { get; set; }
-        
+
         /// <summary>
         /// Will be called if an uncaught exception occurs in <see cref="SystemsManagerConfigurationProvider"/>.Load.
         /// </summary>
@@ -61,10 +67,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// </summary>
         public IParameterProcessor ParameterProcessor { get; set; }
 
-        /// <summary>
-        /// if set, will be used as an extra Parameter filter
+        /// <summary> 
+        /// Filters to limit the request results.
+        /// You can't filter using the parameter name.
         /// </summary>
-        public string Label { get; set; }
+        public List<ParameterStringFilter> Filters { get; }
 
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
@@ -62,7 +62,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         public IParameterProcessor ParameterProcessor { get; set; }
 
         /// <summary>
-        /// if set, will be used with <see cref="Path"/> as an extra filter in the format "Path:Label"
+        /// if set, will be used as an extra Parameter filter
         /// </summary>
         public string Label { get; set; }
 

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
@@ -61,6 +61,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// </summary>
         public IParameterProcessor ParameterProcessor { get; set; }
 
+        /// <summary>
+        /// if set, will be used with <see cref="Path"/> as an extra filter in the format "Path:Label"
+        /// </summary>
+        public string Label { get; set; }
+
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationSourceTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationSourceTests.cs
@@ -35,5 +35,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
             Assert.IsType<SystemsManagerConfigurationProvider>(result);
         }
+
+        [Fact]
+        public void FiltersInitializedTest()
+        {
+            var source = new SystemsManagerConfigurationSource();
+
+            Assert.NotNull(source.Filters);
+        }
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Amazon.Extensions.Configuration.SystemsManager.Internal;
 using Amazon.SimpleSystemsManagement.Model;
 using Moq;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Amazon.Extensions.Configuration.SystemsManager.Tests
@@ -69,6 +69,28 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 {
                     Assert.StartsWith($"{prefix}:", item.Key);
                 }
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("label")]
+        public void CreateLabelFilterTest(string label)
+        { 
+            var output = SystemsManagerProcessor.CreateLabelFilter(label);
+
+            if (label == null)
+            {
+                Assert.Null( output);
+            }
+            else
+            {
+                Assert.NotNull(output);
+                Assert.Single(output);
+                Assert.Equal("Label", output.Single().Key);
+                Assert.Equal("Equals", output.Single().Option);
+                Assert.Single(output.Single().Values);
+                Assert.Equal(label, output.Single().Values.Single());
             }
         }
     }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -71,27 +71,5 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 }
             }
         }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("label")]
-        public void CreateLabelFilterTest(string label)
-        { 
-            var output = SystemsManagerProcessor.CreateLabelFilter(label);
-
-            if (label == null)
-            {
-                Assert.Null( output);
-            }
-            else
-            {
-                Assert.NotNull(output);
-                Assert.Single(output);
-                Assert.Equal("Label", output.Single().Key);
-                Assert.Equal("Equals", output.Single().Option);
-                Assert.Single(output.Single().Values);
-                Assert.Equal(label, output.Single().Values.Single());
-            }
-        }
     }
 }


### PR DESCRIPTION
Added **Filters** to configuration source, this is to be used to add extra filters  when getting parameters by path.

## Description
Adding Filters property (Parameter filter ) gives us the ability to add extra filters  when getting parameters by path, for example a set of parameters labeled with a specific release version, or a certain tag filter and so on.

## Motivation and Context
with the Path, Filters could be used to retrieve a specific filtered parameters set, for example a set of parameters labeled with a specific release version,  

## Testing
- I added unit tests that cover the change 
- Used the the new change in a sample app, deployed it, and I was able to load the parameters that have 
   the provided label correctly.
- tested that the sample app loads the latest version of the parameters (default) if no label is provided. 

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement 