### PR TITLE
Open up IParameterProcessor to allow for multiple configuration pairs

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
 
@@ -39,5 +40,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         }
 
         public virtual string GetValue(Parameter parameter, string path) => parameter.Value;
+
+        public virtual IEnumerable<KeyValuePair<string, string>> Process(Parameter parameter, string path)
+        {
+            return new List<KeyValuePair<string, string>> { { new KeyValuePair<string, string>(GetKey(parameter, path), GetValue(parameter, path)) } };
+        }
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/IParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/IParameterProcessor.cs
@@ -15,6 +15,8 @@
 
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
 
 namespace Amazon.Extensions.Configuration.SystemsManager
 {
@@ -32,19 +34,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         bool IncludeParameter(Parameter parameter, string path);
 
         /// <summary>
-        /// Normalizes the key to be compatible with <see cref="IConfiguration"/>.
+        /// Converts a parameter to configuration pairs to provide for <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="parameter"><see cref="Parameter"/> to be processed</param>
         /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
-        /// <returns>The normalized key</returns>
-        string GetKey(Parameter parameter, string path);
-        
-        /// <summary>
-        /// Gets the value to be returned by <see cref="IConfiguration"/>.
-        /// </summary>
-        /// <param name="parameter"><see cref="Parameter"/> to be processed</param>
-        /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
-        /// <returns>The configuration value</returns>
-        string GetValue(Parameter parameter, string path);
+        /// <returns>The Configuration Pair</returns>
+        IEnumerable<KeyValuePair<string,string>> Process(Parameter input, string path);
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -142,11 +142,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         {
             return parameters
                 .Where(parameter => parameterProcessor.IncludeParameter(parameter, path))
-                .Select(parameter => new
-                {
-                    Key = parameterProcessor.GetKey(parameter, path),
-                    Value = parameterProcessor.GetValue(parameter, path)
-                })
+                .SelectMany(parameter => parameterProcessor.Process(parameter, path))
                 .ToDictionary(parameter => parameter.Key, parameter => parameter.Value, StringComparer.OrdinalIgnoreCase);
         }
     }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -57,7 +57,15 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             foreach (var parameter in _parameters)
             {
                 _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.Process(parameter, Path))
+                                       .Returns(new List<KeyValuePair<string, string>>
+                                       {
+                                           {
+                                               new KeyValuePair<string, string>(
+                                                   parameter.Value,
+                                                   parameter.Value)
+                                           }
+                                       });
             }
 
             var getData = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -32,8 +32,15 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             foreach (var parameter in parameters)
             {
                 _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
-                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.Process(parameter, path))
+                                       .Returns(new List<KeyValuePair<string, string>> 
+                                       { 
+                                           { 
+                                               new KeyValuePair<string, string>(
+                                                   parameter.Value,
+                                                   parameter.Value)
+                                           } 
+                                       });
             }
 
             var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);
@@ -57,8 +64,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             foreach (var parameter in parameters)
             {
                 _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
-                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
+                _parameterProcessorMock.Setup(processor => processor.Process(parameter, path))
+                                       .Returns(new List<KeyValuePair<string, string>>
+                                       {
+                                           {
+                                               new KeyValuePair<string, string>(parameter.Value,parameter.Value)
+                                           }
+                                       }) ;
             }
 
             var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow for multiple configuration pairs to be returned from one AWS parameter.

## Description
<!--- Describe your changes in detail -->
The current custom Parameter processing logic only allows one parameter to one configuration, and enforcing the AWS hierarchy. To open it up, I've changed `IParamaterProcessor` to consolidate the methods and have it return an IEnumerable.

This allows for custom processors with their own hierarchy or formatting to be implemented. The `DefaultParameterProcessor` still works with the standard convention. 

This change would break custom implementations of custom processors that inherit off `IParameterProcessor` (ones that inherit off the default are unaffected)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Parameter convention requires multiple parameters to be created within AWS. This can become difficult to maintain through the web console as more parameters are added. 

https://github.com/aws/aws-dotnet-extensions-configuration/issues/51
To have parameters as a configuration section, the following parameter processor can be used (hooking into existing parser). This assumes values are unique and no key prefix added to configuration.
``` Csharp
public class JsonParameterProcessor : DefaultParameterProcessor
    {
        public override IEnumerable<KeyValuePair<string, string>> Process(Parameter parameter, string path)
        {
            return JsonConfigurationParser.Parse(parameter.Value);

        }

    }
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Modified existing tests to mock the newer function, and run all tests to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
^ only of custom implemented logic

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
