### PR TITLE
Add support for an appsettings-like format of the parameter value

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/IParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/IParameterProcessor.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
 
@@ -29,6 +31,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <param name="parameter"><see cref="Parameter"/> to be processed</param>
         /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
         /// <returns>Boolean that determines if the Parameter wil be processed further</returns>
+        [Obsolete("Include method is no longer used by the interface. Please override DefaultParameterProcessor class if you want to use this method.")]
         bool IncludeParameter(Parameter parameter, string path);
 
         /// <summary>
@@ -37,6 +40,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <param name="parameter"><see cref="Parameter"/> to be processed</param>
         /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
         /// <returns>The normalized key</returns>
+        [Obsolete("GetKey method is no longer used by the interface. Please override DefaultParameterProcessor class if you want to use this method.")]
         string GetKey(Parameter parameter, string path);
         
         /// <summary>
@@ -45,6 +49,15 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <param name="parameter"><see cref="Parameter"/> to be processed</param>
         /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
         /// <returns>The configuration value</returns>
+        [Obsolete("GetValue method is no longer used by the interface. Please override DefaultParameterProcessor class if you want to use this method.")]
         string GetValue(Parameter parameter, string path);
+
+        /// <summary>
+        /// Process parameters from AWS Parameter Store into a dictionary for <see cref="IConfiguration"/>
+        /// </summary>
+        /// <param name="parameters">Enumeration of <see cref="Parameter"/>s to be processed</param>
+        /// <param name="path">Path used when retrieving the <see cref="Parameter"/></param>
+        /// <returns>Configuration values for <see cref="IConfiguration"/></returns>
+        IDictionary<string, string> ProcessParameters(IEnumerable<Parameter> parameters, string path);
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Amazon.SimpleSystemsManagement.Model;
+using Moq;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class DefaultParameterProcessorTests
+    {
+        private readonly IParameterProcessor _parameterProcessor;
+
+        public DefaultParameterProcessorTests()
+        {
+            _parameterProcessor = new DefaultParameterProcessor();
+        }
+
+        [Fact]
+        public void ProcessParametersTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
+                new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
+                new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
+                new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"},
+            };
+
+            const string path = "/start/path";
+
+            var data = _parameterProcessor.ProcessParameters(parameters, path);
+
+            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
+        }
+
+        [Fact]
+        public void ProcessParametersRootTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/p1", Value = "p1"},
+                new Parameter {Name = "p2", Value = "p2"},
+            };
+
+            const string path = "/";
+
+            var data = _parameterProcessor.ProcessParameters(parameters, path);
+
+            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
+        }
+    }
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using Amazon.SimpleSystemsManagement.Model;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class JsonParameterProcessorTests
+    {
+        private readonly IParameterProcessor _parameterProcessor;
+
+        public JsonParameterProcessorTests()
+        {
+            _parameterProcessor = new JsonParameterProcessor();
+        }
+
+        [Fact]
+        public void ProcessParametersTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/p1", Value = "{\"p1\": \"p1\"}"},
+                new Parameter {Name = "p2", Value = "{\"p2\": \"p2\"}"},
+                new Parameter {Name = "/p1/p3", Value = "{\"p3key\": \"p3value\"}"},
+                new Parameter {Name = "/p4", Value = "{\"p4key\": { \"p5key\": \"p5value\" } }"},
+                new Parameter {Name = "/p6", Value = "{\"p6key\": { \"p7key\": { \"p8key\": \"p8value\" } } }"},
+            };
+            var expected = new Dictionary<string, string>() {
+                { "p1", "p1" },
+                { "p2", "p2" },
+                { "p3key", "p3value" },
+                { "p4key:p5key", "p5value" },
+                { "p6key:p7key:p8key", "p8value" },
+            };
+
+            const string path = "/";
+
+            var data = _parameterProcessor.ProcessParameters(parameters, path);
+
+            Assert.All(expected, item => Assert.Equal(item.Value, data[item.Key]));
+        }
+    }
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -36,15 +36,12 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
         private readonly SystemsManagerConfigurationProvider _provider;
         private readonly Mock<ISystemsManagerProcessor> _systemsManagerProcessorMock;
-        private readonly Mock<IParameterProcessor> _parameterProcessorMock;
 
         public SystemsManagerConfigurationProviderTests()
         {
-            _parameterProcessorMock = new Mock<IParameterProcessor>();
             _systemsManagerProcessorMock = new Mock<ISystemsManagerProcessor>();
             var source = new SystemsManagerConfigurationSource
             {
-                ParameterProcessor = _parameterProcessorMock.Object,
                 AwsOptions = new AWSOptions(),
                 Path = Path
             };
@@ -54,13 +51,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         [Fact]
         public void LoadTest()
         {
-            foreach (var parameter in _parameters)
-            {
-                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
-            }
-
-            var getData = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var getData = new DefaultParameterProcessor().ProcessParameters(_parameters, Path);
 
             _systemsManagerProcessorMock.Setup(p => p.GetDataAsync()).ReturnsAsync(() => getData);
 
@@ -71,7 +62,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 Assert.True(_provider.TryGet(parameter.Value, out _));
             }
 
-            _parameterProcessorMock.VerifyAll();
+            _systemsManagerProcessorMock.VerifyAll();
         }
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -9,65 +9,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 {
     public class SystemsManagerProcessorTests
     {
-        private readonly Mock<IParameterProcessor> _parameterProcessorMock;
-
-        public SystemsManagerProcessorTests()
-        {
-            _parameterProcessorMock = new Mock<IParameterProcessor>();
-        }
-
-        [Fact]
-        public void ProcessParametersTest()
-        {
-            var parameters = new List<Parameter>
-            {
-                new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
-                new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
-                new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
-                new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"},
-            };
-
-            const string path = "/start/path";
-
-            foreach (var parameter in parameters)
-            {
-                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
-                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
-            }
-
-            var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);
-
-            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
-
-            _parameterProcessorMock.VerifyAll();
-        }
-
-        [Fact]
-        public void ProcessParametersRootTest()
-        {
-            var parameters = new List<Parameter>
-            {
-                new Parameter {Name = "/p1", Value = "p1"},
-                new Parameter {Name = "p2", Value = "p2"},
-            };
-
-            const string path = "/";
-
-            foreach (var parameter in parameters)
-            {
-                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
-                _parameterProcessorMock.Setup(processor => processor.GetValue(parameter, path)).Returns(parameter.Value);
-            }
-
-            var data = SystemsManagerProcessor.ProcessParameters(parameters, path, _parameterProcessorMock.Object);
-
-            Assert.All(data, item => Assert.Equal(item.Value, item.Key));
-
-            _parameterProcessorMock.VerifyAll();
-        }
-
         [Theory]
         [InlineData("/aws/reference/secretsmanager/", true)]
         [InlineData("/not-sm-path/", false)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This code allows to use SSM parameter store as ConfigurationSection, so solves #51 .

## Description
<!--- Describe your changes in detail -->
The change lets the library user decide how much parameters are stored as one Parameter Store value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
It fixes #51.
It is also an alternative to #54, with the following pros:
* Less breaking change - people, that already integrated with previous versions should have no problem with porting to the new version. However, their build will still failed if they implemented IParameterProcessor directly, instead of extending the DefaultParameterProcessor
* JsonParameterProcessor included in the project, so that everyone can easily use it

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Solution covered with unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
