### PR TITLE
Updated packages to attempt to allow this to continue being used.

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -39,8 +39,8 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.*" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.100.*" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.5.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.*" />
   </ItemGroup>


### PR DESCRIPTION
This is a more minimal version of #73 

## Description
Package updates, net 0 change.

## Motivation and Context
At the moment, upon trying to update various AWS libraries to 3.5.x build failures occur due to conflicting versions of AWS.Core
See also: #74 

## Testing
Ran unit tests, as I didn't touch any code, I expected this to be trivial in nature.

## Screenshots (if appropriate)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [  ] My change requires a change to the documentation
- [  ] I have updated the documentation accordingly
- [  ] I have read the **README** document
- [  ] I have added tests to cover my changes
- [  ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
