### PR TITLE
Add AppConfig support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ generator/.vs/**
 **/*.partial.csproj
 
 **/.DS_Store
+
+#JetBrains Rider user folders
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 # AWS .NET Configuration Extension for Systems Manager
 [![nuget](https://img.shields.io/nuget/v/Amazon.Extensions.Configuration.SystemsManager.svg)](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/)
 
-[Amazon.Extensions.Configuration.SystemsManager](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/) simplifies using [AWS SSM](https://aws.amazon.com/systems-manager/)'s [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) as a source for configuration information for .NET Core applications.  This project was contributed by [@KenHundley](https://github.com/KenHundley).
+[Amazon.Extensions.Configuration.SystemsManager](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/) simplifies using [AWS SSM](https://aws.amazon.com/systems-manager/)'s [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) and [AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) as a source for configuration information for .NET Core applications.  This project was contributed by [@KenHundley](https://github.com/KenHundley) and [@MichalGorski](https://github.com/mgorski-mg).
 
 The library introduces the following dependencies:
 
 * [AWSSDK.Extensions.NETCore.Setup](https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup/)
 * [AWSSDK.SimpleSystemsManagement](https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement/)
+* [AWSSDK.AppConfig](https://www.nuget.org/packages/AWSSDK.AppConfig/)
 * [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration)
 
 # Getting Started
@@ -16,7 +17,7 @@ The library introduces the following dependencies:
 Follow the examples below to see how the library can be integrated into your application.  This extension adheres to the same practices and conventions of [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1).
 
 ## ASP.NET Core Example
-The most common use case for this library is to pull configuration from Parameter Store.  You can easily add this functionality by adding 1 line of code:
+One of the common use cases for this library is to pull configuration from Parameter Store.  You can easily add this functionality by adding 1 line of code:
 
 ```csharp
 public class Program
@@ -36,6 +37,26 @@ public class Program
 }
 ```
 
+Second possibility is to pull configuration from AppConfig.  You can easily add this functionality by adding 1 line of code:
+
+```csharp
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateWebHostBuilder(args).Build().Run();
+    }
+
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+        WebHost.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration(builder =>
+            {
+                builder.AddAppConfig("AppConfigApplicationId", "AppConfigEnvironmentId", "AppConfigConfigurationProfileId");
+            })
+            .UseStartup<Startup>();
+}
+```
+
 ## HostBuilder Example
 Microsoft introduced [.NET Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.1) to de-couple HTTP pipeline from the Web Host API.  The Generic Host library allows you to write non-HTTP services using configuration, dependency injection, and logging features.  The sample code below shows you how to use the the AWS .NET Configuration Extension library:
 
@@ -48,6 +69,7 @@ namespace HostBuilderExample
             .ConfigureAppConfiguration((hostingContext, config) =>
             {
                 config.AddSystemsManager("/my-application/");
+                config.AddAppConfig("AppConfigApplicationId", "AppConfigEnvironmentId", "AppConfigConfigurationProfileId");
             })
             .ConfigureServices((sc) => { ... })
             .Build();
@@ -61,17 +83,13 @@ namespace HostBuilderExample
 
 For more complete examples, take a look at sample projects available in [samples directory](https://github.com/aws/aws-dotnet-extensions-configuration/tree/master/samples).
 
-
 # Reloading in AWS Lambda
 
-The `reloadAfter` parameter on `AddSystemsManager()` enables automatic reloading of configuration data from Parameter Store as a background task.
+The `reloadAfter` parameter on `AddSystemsManager()` and `AddAppConfig()` enables automatic reloading of configuration data from Parameter Store or AppConfig as a background task.
 
-In AWS Lambda, background tasks are paused after processing a Lambda event.  This could disrupt the provider from 
-retrieving the latest configuration data from Parameter Store. To ensure the reload is performed within a Lambda event,
-we recommend calling the extension method `WaitForSystemsManagerReloadToComplete` from the `IConfiguration` object in 
-your Lambda function. This method will immediately return unless a reload is currently being performed.  The `WaitForSystemsManagerReloadToComplete` extension method to `IConfiguration` is available when you add the a
-`using Amazon.Extensions.Configuration.SystemsManager` statement.  See the example below:
+## Reloading in AWS Lambda
 
+In AWS Lambda, background tasks are paused after processing a Lambda event. This could disrupt the provider from retrieving the latest configuration data from Systems Manager. To ensure the reload is performed within a Lambda event, we recommend calling the extension method `WaitForSystemsManagerReloadToComplete` from the `IConfiguration` object in your Lambda function. This method will immediately return unless a reload is currently being performed. See the example below:
 
 ```csharp
 using Amazon.Extensions.Configuration.SystemsManager
@@ -87,12 +105,13 @@ var configurations = configurationBuilder.Build();
 configurations.WaitForSystemsManagerReloadToComplete(TimeSpan.FromSeconds(5));
 ```
 
+For AppConfig in Lambda you should use [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html).
+
 # Getting Help
 
 We use the [GitHub issues](https://github.com/aws/aws-dotnet-extensions-configuration/issues) for tracking bugs and feature requests and have limited bandwidth to address them.
 
 If you think you may have found a bug, please open an [issue](https://github.com/aws/aws-dotnet-extensions-configuration/issues/new)
-
 
 # Contributing
 

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>
@@ -44,8 +44,9 @@
   </Choose>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.AppConfig" Version="3.5.0.59" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.5.1.7" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.5.8.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
   </ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
@@ -14,28 +14,31 @@
  */
 
 using System;
-using System.Collections.Generic;
 using Amazon.Extensions.NETCore.Setup;
-using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
 
-namespace Amazon.Extensions.Configuration.SystemsManager
+namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
 {
     /// <inheritdoc />
     /// <summary>
-    /// Represents AWS Systems Manager Parameter Store variables as an <see cref="ISystemsManagerConfigurationSource" />.
+    /// Represents AWS Systems Manager AppConfig variables as an <see cref="ISystemsManagerConfigurationSource" />.
     /// </summary>
-    public class SystemsManagerConfigurationSource : ISystemsManagerConfigurationSource
+    public class AppConfigConfigurationSource : ISystemsManagerConfigurationSource
     {
-        public SystemsManagerConfigurationSource()
-        {
-            Filters = new List<ParameterStringFilter>();
-        }
+        /// <summary>
+        /// AppConfig Application Id.
+        /// </summary>
+        public string ApplicationId { get; set; }
 
         /// <summary>
-        /// A Path used to filter parameters.
+        /// AppConfig Environment Id.
         /// </summary>
-        public string Path { get; set; }
+        public string EnvironmentId { get; set; }
+
+        /// <summary>
+        /// AppConfig Configuration Profile Id.
+        /// </summary>
+        public string ConfigProfileId { get; set; }
 
         /// <summary>
         /// <see cref="AWSOptions"/> used to create an AWS Systems Manager Client />.
@@ -48,24 +51,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// <inheritdoc />
         public TimeSpan? ReloadAfter { get; set; }
 
-        /// <summary>
-        /// Prepends the supplied Prefix to all result keys
-        /// </summary>
-        public string Prefix { get; set; }
-
         /// <inheritdoc />
         public Action<SystemsManagerExceptionContext> OnLoadException { get; set; }
-
-        /// <summary>
-        /// Implementation of <see cref="IParameterProcessor"/> used to process <see cref="Parameter"/> results. Defaults to <see cref="DefaultParameterProcessor"/>.
-        /// </summary>
-        public IParameterProcessor ParameterProcessor { get; set; }
-
-        /// <summary> 
-        /// Filters to limit the request results.
-        /// You can't filter using the parameter name.
-        /// </summary>
-        public List<ParameterStringFilter> Filters { get; }
 
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
@@ -39,6 +39,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
         /// AppConfig Configuration Profile Id.
         /// </summary>
         public string ConfigProfileId { get; set; }
+        
+        /// <summary>
+        /// AppConfig Client Id.
+        /// </summary>
+        public string ClientId { get; set; }
 
         /// <summary>
         /// <see cref="AWSOptions"/> used to create an AWS Systems Manager Client />.

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Extensions.Configuration
             if (source.ApplicationId == null) throw new ArgumentNullException(nameof(source.ApplicationId));
             if (source.EnvironmentId == null) throw new ArgumentNullException(nameof(source.EnvironmentId));
             if (source.ConfigProfileId == null) throw new ArgumentNullException(nameof(source.ConfigProfileId));
+            if (source.ClientId == null) throw new ArgumentNullException(nameof(source.ClientId));
 
             if (source.AwsOptions == null)
             {
@@ -246,6 +247,7 @@ namespace Microsoft.Extensions.Configuration
                 ApplicationId = applicationId,
                 EnvironmentId = environmentId,
                 ConfigProfileId = configProfileId,
+                ClientId = Guid.NewGuid().ToString(),
                 AwsOptions = awsOptions,
                 Optional = optional,
                 ReloadAfter = reloadAfter

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
@@ -1,0 +1,255 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Extensions.Configuration.SystemsManager;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
+using Amazon.Extensions.NETCore.Setup;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Extension methods for registering <see cref="SystemsManagerConfigurationProvider"/> with <see cref="IConfigurationBuilder"/>.
+    /// </summary>
+    public static class AppConfigExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, bool optional, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, optional, reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, bool optional)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, optional));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, bool optional, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, optional: optional, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, bool optional)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId, optional: optional));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfig(ConfigureSource(applicationId, environmentId, configProfileId));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="source">Configuration source.</param>
+        /// <exception cref="ArgumentNullException"><see cref="source"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.ApplicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.EnvironmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.ConfigProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, AppConfigConfigurationSource source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (source.ApplicationId == null) throw new ArgumentNullException(nameof(source.ApplicationId));
+            if (source.EnvironmentId == null) throw new ArgumentNullException(nameof(source.EnvironmentId));
+            if (source.ConfigProfileId == null) throw new ArgumentNullException(nameof(source.ConfigProfileId));
+
+            if (source.AwsOptions == null)
+            {
+                source.AwsOptions = AwsOptionsProvider.GetAwsOptions(builder);
+            }
+
+            return builder.Add(source);
+        }
+
+        private static AppConfigConfigurationSource ConfigureSource(
+            string applicationId,
+            string environmentId,
+            string configProfileId,
+            AWSOptions awsOptions = null,
+            bool optional = false,
+            TimeSpan? reloadAfter = null
+        )
+        {
+            return new AppConfigConfigurationSource
+            {
+                ApplicationId = applicationId,
+                EnvironmentId = environmentId,
+                ConfigProfileId = configProfileId,
+                AwsOptions = awsOptions,
+                Optional = optional,
+                ReloadAfter = reloadAfter
+            };
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.AppConfig;
+using Amazon.AppConfig.Model;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
+{
+    public class AppConfigProcessor : ISystemsManagerProcessor
+    {
+        private AppConfigConfigurationSource Source { get; }
+
+        public AppConfigProcessor(AppConfigConfigurationSource source)
+        {
+            if (source.ApplicationId == null) throw new ArgumentNullException(nameof(source.ApplicationId));
+            if (source.EnvironmentId == null) throw new ArgumentNullException(nameof(source.EnvironmentId));
+            if (source.ConfigProfileId == null) throw new ArgumentNullException(nameof(source.ConfigProfileId));
+            if (source.AwsOptions == null) throw new ArgumentNullException(nameof(source.AwsOptions));
+            
+            Source = source;
+        }
+
+        public async Task<IDictionary<string, string>> GetDataAsync()
+        {
+            var request = new GetConfigurationRequest
+            {
+                Application = Source.ApplicationId,
+                Environment = Source.EnvironmentId,
+                Configuration = Source.ConfigProfileId,
+                ClientId = Guid.NewGuid().ToString()
+            };
+
+            using (var client = Source.AwsOptions.CreateServiceClient<IAmazonAppConfig>())
+            {
+                if (client is AmazonAppConfigClient impl)
+                {
+                    impl.BeforeRequestEvent += ServiceClientAppender.ServiceClientBeforeRequestEvent;
+                }
+
+                var response = await client.GetConfigurationAsync(request).ConfigureAwait(false);
+
+                return JsonConfigurationParser.Parse(response.Content);
+            }
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/ISystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/ISystemsManagerConfigurationSource.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Amazon.Extensions.Configuration.SystemsManager
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Represents AWS Systems Manager variables as an <see cref="ISystemsManagerConfigurationSource" />.
+    /// </summary>
+    public interface ISystemsManagerConfigurationSource : IConfigurationSource
+    {
+        /// <summary>
+        /// Determines if loading configuration data from AWS Systems Manager Parameter Store is optional.
+        /// </summary>
+        bool Optional { get; set; }
+
+        /// <summary>
+        /// Parameters will be reloaded from the AWS Systems Manager Parameter Store after the specified time frame
+        /// </summary>
+        TimeSpan? ReloadAfter { get; set; }
+
+        /// <summary>
+        /// Will be called if an uncaught exception occurs in <see cref="SystemsManagerConfigurationProvider"/>.Load.
+        /// </summary>
+        Action<SystemsManagerExceptionContext> OnLoadException { get; set; }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/AwsOptionsProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/AwsOptionsProvider.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Extensions.NETCore.Setup;
+using Microsoft.Extensions.Configuration;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Internal
+{
+    public static class AwsOptionsProvider
+    {
+        private const string AwsOptionsConfigurationKey = "AWS_CONFIGBUILDER_AWSOPTIONS";
+        
+        public static AWSOptions GetAwsOptions(IConfigurationBuilder builder)
+        {
+            if (builder.Properties.TryGetValue(AwsOptionsConfigurationKey, out var value) && value is AWSOptions existingOptions)
+            {
+                return existingOptions;
+            }
+
+            var config = builder.Build();
+            var newOptions = config.GetAWSOptions();
+
+            if (builder.Properties.ContainsKey(AwsOptionsConfigurationKey))
+            {
+                builder.Properties[AwsOptionsConfigurationKey] = newOptions;
+            }
+            else
+            {
+                builder.Properties.Add(AwsOptionsConfigurationKey, newOptions);
+            }
+
+            return newOptions;
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/ISystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/ISystemsManagerProcessor.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Internal
+{
+    public interface ISystemsManagerProcessor
+    {
+        Task<IDictionary<string, string>> GetDataAsync();
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/ServiceClientAppender.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/ServiceClientAppender.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Reflection;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Amazon.Runtime;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Internal
+{
+    public static class ServiceClientAppender
+    {
+        private const string UserAgentHeader = "User-Agent";
+        private static readonly string AssemblyVersion = typeof(AppConfigProcessor).GetTypeInfo().Assembly.GetName().Version.ToString();
+
+        public static void ServiceClientBeforeRequestEvent(object sender, RequestEventArgs e)
+        {
+            if (e is WebServiceRequestEventArgs args)
+            {
+                if (args.Headers.ContainsKey(UserAgentHeader))
+                {
+                    args.Headers[UserAgentHeader] = args.Headers[UserAgentHeader] + " SSMConfigProvider/" + AssemblyVersion;
+                }
+            }
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -13,23 +13,16 @@
  * permissions and limitations under the License.
  */
 
-using Amazon.Runtime;
 using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 
 namespace Amazon.Extensions.Configuration.SystemsManager.Internal
 {
-    public interface ISystemsManagerProcessor
-    {
-        Task<IDictionary<string, string>> GetDataAsync();
-    }
-
     public class SystemsManagerProcessor : ISystemsManagerProcessor
     {
         private const string SecretsManagerPath = "/aws/reference/secretsmanager/";
@@ -38,6 +31,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
 
         public SystemsManagerProcessor(SystemsManagerConfigurationSource source)
         {
+            if (source.AwsOptions == null) throw new ArgumentNullException(nameof(source.AwsOptions));
+            if (source.Path == null) throw new ArgumentNullException(nameof(source.Path));
+            
             Source = source;
             Source.ParameterProcessor = Source.ParameterProcessor ?? new DefaultParameterProcessor();
         }
@@ -55,7 +51,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
             {
                 if (client is AmazonSimpleSystemsManagementClient impl)
                 {
-                    impl.BeforeRequestEvent += ServiceClientBeforeRequestEvent;
+                    impl.BeforeRequestEvent += ServiceClientAppender.ServiceClientBeforeRequestEvent;
                 }
 
                 var parameters = new List<Parameter>();
@@ -77,7 +73,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
             {
                 if (client is AmazonSimpleSystemsManagementClient impl)
                 {
-                    impl.BeforeRequestEvent += ServiceClientBeforeRequestEvent;
+                    impl.BeforeRequestEvent += ServiceClientAppender.ServiceClientBeforeRequestEvent;
                 }
 
                 var response = await client.GetParameterAsync(new GetParameterRequest { Name = Source.Path, WithDecryption = true }).ConfigureAwait(false);
@@ -109,17 +105,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                     Value = parameterProcessor.GetValue(parameter, path)
                 })
                 .ToDictionary(parameter => parameter.Key, parameter => parameter.Value, StringComparer.OrdinalIgnoreCase);
-        }
-
-        private const string UserAgentHeader = "User-Agent";
-        private static readonly string AssemblyVersion = typeof(SystemsManagerProcessor).GetTypeInfo().Assembly.GetName().Version.ToString();
-
-        private static void ServiceClientBeforeRequestEvent(object sender, RequestEventArgs e)
-        {
-            if (e is WebServiceRequestEventArgs args && args.Headers.ContainsKey(UserAgentHeader))
-            {
-                args.Headers[UserAgentHeader] = args.Headers[UserAgentHeader] + " SSMConfigProvider/" + AssemblyVersion;
-            }
         }
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExceptionContext.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExceptionContext.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using Microsoft.Extensions.Configuration;
 
 namespace Amazon.Extensions.Configuration.SystemsManager
 {
@@ -21,9 +22,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager
     public class SystemsManagerExceptionContext
     {
         /// <summary>
-        /// The <see cref="SystemsManagerConfigurationProvider" /> that caused the exception.
+        /// The <see cref="IConfigurationProvider" /> that caused the exception.
         /// </summary>
-        public SystemsManagerConfigurationProvider Provider { get; set; }
+        public IConfigurationProvider Provider { get; set; }
 
         /// <summary>The exception that occured in Load.</summary>
         public Exception Exception { get; set; }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -15,6 +15,7 @@
 
 using System;
 using Amazon.Extensions.Configuration.SystemsManager;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
 using Amazon.Extensions.NETCore.Setup;
 
 // ReSharper disable once CheckNamespace
@@ -25,8 +26,6 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class SystemsManagerExtensions
     {
-        private const string AwsOptionsConfigurationKey = "AWS_CONFIGBUILDER_AWSOPTIONS";
-
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager Parameter Store with a specified path.
         /// </summary>
@@ -186,7 +185,7 @@ namespace Microsoft.Extensions.Configuration
             if (string.IsNullOrWhiteSpace(source.Path)) throw new ArgumentNullException(nameof(source.Path));
             if (source.AwsOptions != null) return builder.Add(source);
 
-            source.AwsOptions = builder.GetAwsOptions();
+            source.AwsOptions = AwsOptionsProvider.GetAwsOptions(builder);
             return builder.Add(source);
         }
 
@@ -199,28 +198,6 @@ namespace Microsoft.Extensions.Configuration
                 configurationSource.Optional = optional;
                 configurationSource.ReloadAfter = reloadAfter;
             };
-        }
-
-        private static AWSOptions GetAwsOptions(this IConfigurationBuilder builder)
-        {
-            if (builder.Properties.TryGetValue(AwsOptionsConfigurationKey, out var value) && value is AWSOptions existingOptions)
-            {
-                return existingOptions;
-            }
-
-            var config = builder.Build();
-            var newOptions = config.GetAWSOptions();
-
-            if (builder.Properties.ContainsKey(AwsOptionsConfigurationKey))
-            {
-                builder.Properties[AwsOptionsConfigurationKey] = newOptions;
-            }
-            else
-            {
-                builder.Properties.Add(AwsOptionsConfigurationKey, newOptions);
-            }
-
-            return newOptions;
         }
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -155,7 +155,6 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="path">The path that variable names must start with. The path will be removed from the variable names.</param>
-        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
         /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
@@ -14,9 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigConfigurationSourceTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigConfigurationSourceTests.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Amazon.Extensions.NETCore.Setup;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class AppConfigConfigurationSourceTests
+    {
+        [Fact]
+        public void BuildShouldReturnSystemsManagerConfigurationProvider()
+        {
+            var source = new AppConfigConfigurationSource
+            {
+                ApplicationId = "appId",
+                EnvironmentId = "envId",
+                ConfigProfileId = "profileId",
+                AwsOptions = new AWSOptions()
+            };
+            var builder = new ConfigurationBuilder();
+
+            var result = source.Build(builder);
+
+            Assert.IsType<SystemsManagerConfigurationProvider>(result);
+        }
+    }
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigExtensionsTests.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class AppConfigExtensionsTests
+    {
+        [Fact]
+        public void AddAppConfigWithProperInputShouldReturnProperConfigurationBuilder()
+        {
+            var expectedBuilder = new ConfigurationBuilder();
+            expectedBuilder.Sources.Add(new Mock<AppConfigConfigurationSource>().Object);
+            const string applicationId = "appId";
+            const string environmentId = "envId";
+            const string configProfileId = "profId";
+
+            var builder = new ConfigurationBuilder();
+            builder.AddAppConfig(applicationId, environmentId, configProfileId);
+
+            Assert.Contains(
+                builder.Sources,
+                source => source is AppConfigConfigurationSource configurationSource
+                       && configurationSource.ApplicationId == applicationId
+                       && configurationSource.EnvironmentId == environmentId
+                       && configurationSource.ConfigProfileId == configProfileId
+            );
+        }
+
+        [Fact]
+        public void AddAppConfigWithoutAwsOptionsShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfig("appId", "envId", "profileId", awsOptions: null);
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("awsOptions", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigWithoutApplicationIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfig(null, "envId", "profileId");
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("applicationId", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigWithoutEnvironmentIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfig("appId", null, "profileId");
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("environmentId", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigWithoutProfileIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfig("appId", "envId", null);
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("configProfileId", ex.Message);
+        }
+    }
+}

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerConfigurationProviderTests.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Collections.Generic;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
 using Amazon.Extensions.Configuration.SystemsManager.Internal;
 using Amazon.Extensions.NETCore.Setup;
 using Amazon.SimpleSystemsManagement.Model;
@@ -24,54 +25,91 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 {
     public class SystemsManagerConfigurationProviderTests
     {
-        private readonly List<Parameter> _parameters = new List<Parameter>
+        private readonly Mock<ISystemsManagerProcessor> _systemsManagerProcessorMock = new Mock<ISystemsManagerProcessor>();
+
+        [Fact]
+        public void LoadForParameterStoreShouldReturnProperParameters()
         {
-            new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
-            new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
-            new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
-            new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"}
-        };
-
-        private const string Path = "/start/path";
-
-        private readonly SystemsManagerConfigurationProvider _provider;
-        private readonly Mock<ISystemsManagerProcessor> _systemsManagerProcessorMock;
-        private readonly Mock<IParameterProcessor> _parameterProcessorMock;
-
-        public SystemsManagerConfigurationProviderTests()
-        {
-            _parameterProcessorMock = new Mock<IParameterProcessor>();
-            _systemsManagerProcessorMock = new Mock<ISystemsManagerProcessor>();
-            var source = new SystemsManagerConfigurationSource
+            var parameters = new List<Parameter>
             {
-                ParameterProcessor = _parameterProcessorMock.Object,
-                AwsOptions = new AWSOptions(),
-                Path = Path
+                new Parameter {Name = "/start/path/p1/p2-1", Value = "p1:p2-1"},
+                new Parameter {Name = "/start/path/p1/p2-2", Value = "p1:p2-2"},
+                new Parameter {Name = "/start/path/p1/p2/p3-1", Value = "p1:p2:p3-1"},
+                new Parameter {Name = "/start/path/p1/p2/p3-2", Value = "p1:p2:p3-2"}
             };
-            _provider = new SystemsManagerConfigurationProvider(source, _systemsManagerProcessorMock.Object);
+            var parameterProcessorMock = new Mock<IParameterProcessor>();
+            var provider = ConfigureParameterStoreConfigurationProvider(parameterProcessorMock, parameters);
+
+            provider.Load();
+
+            foreach (var parameter in parameters)
+            {
+                Assert.True(provider.TryGet(parameter.Value, out _));
+            }
+
+            parameterProcessorMock.VerifyAll();
         }
 
         [Fact]
-        public void LoadTest()
+        public void LoadForAppConfigShouldReturnProperValues()
         {
-            foreach (var parameter in _parameters)
+            var values = new Dictionary<string, string>
             {
-                _parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, Path)).Returns(true);
-                _parameterProcessorMock.Setup(processor => processor.GetKey(parameter, Path)).Returns(parameter.Value);
+                { "testKey", "testValue" },
+                { "testKey2", "testValue2" },
+                { "testKey3", "testValue3" },
+                { "testKey4", "testValue4" },
+                { "testKey5", "testValue5" }
+            };
+            var provider = ConfigureAppConfigConfigurationProvider(values);
+
+            provider.Load();
+
+            foreach (var parameter in values)
+            {
+                Assert.True(provider.TryGet(parameter.Key, out _));
+            }
+        }
+
+        private SystemsManagerConfigurationProvider ConfigureParameterStoreConfigurationProvider(Mock<IParameterProcessor> parameterProcessorMock, IReadOnlyCollection<Parameter> parameters)
+        {
+            const string path = "/start/path";
+            var source = new SystemsManagerConfigurationSource
+            {
+                ParameterProcessor = parameterProcessorMock.Object,
+                AwsOptions = new AWSOptions(),
+                Path = path
+            };
+            var provider = new SystemsManagerConfigurationProvider(source, _systemsManagerProcessorMock.Object);
+
+            foreach (var parameter in parameters)
+            {
+                parameterProcessorMock.Setup(processor => processor.IncludeParameter(parameter, path)).Returns(true);
+                parameterProcessorMock.Setup(processor => processor.GetKey(parameter, path)).Returns(parameter.Value);
             }
 
-            var getData = SystemsManagerProcessor.ProcessParameters(_parameters, Path, _parameterProcessorMock.Object);
+            var getData = SystemsManagerProcessor.ProcessParameters(parameters, path, parameterProcessorMock.Object);
 
             _systemsManagerProcessorMock.Setup(p => p.GetDataAsync()).ReturnsAsync(() => getData);
 
-            _provider.Load();
+            return provider;
+        }
 
-            foreach (var parameter in _parameters)
+        private SystemsManagerConfigurationProvider ConfigureAppConfigConfigurationProvider(IDictionary<string, string> values)
+        {
+            var source = new AppConfigConfigurationSource
             {
-                Assert.True(_provider.TryGet(parameter.Value, out _));
-            }
+                ApplicationId = "appId",
+                EnvironmentId = "envId",
+                ConfigProfileId = "profileId",
+                AwsOptions = new AWSOptions()
+            };
 
-            _parameterProcessorMock.VerifyAll();
+            _systemsManagerProcessorMock.Setup(p => p.GetDataAsync()).ReturnsAsync(() => values);
+            
+            var provider = new SystemsManagerConfigurationProvider(source, _systemsManagerProcessorMock.Object);
+
+            return provider;
         }
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerExtensionsTests.cs
@@ -45,17 +45,17 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
         public static TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string> SourceExtensionData => new TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string>
         {
-            {builder => builder.AddSystemsManager(CreateSource(null, null, false, null, null)), typeof(ArgumentNullException), "Parameter name: Path"},
-            {builder => builder.AddSystemsManager(CreateSource(null, null, true, null, null)), typeof(ArgumentNullException), "Parameter name: Path"},
+            {builder => builder.AddSystemsManager(CreateSource(null, null, false, null, null)), typeof(ArgumentNullException), "Path"},
+            {builder => builder.AddSystemsManager(CreateSource(null, null, true, null, null)), typeof(ArgumentNullException), "Path"},
             {builder => builder.AddSystemsManager(CreateSource("/path", null, false, null, null)), null, null},
             {builder => builder.AddSystemsManager(CreateSource("/aws/reference/secretsmanager/somevalue", null, false, null, null)), null, null}
         };
 
         public static TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string> WithAWSOptionsExtensionData => new TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string>
         {
-            {builder => builder.AddSystemsManager(null, null), typeof(ArgumentNullException), "Parameter name: path"},
-            {builder => builder.AddSystemsManager("/path", null), typeof(ArgumentNullException), "Parameter name: awsOptions"},
-            {builder => builder.AddSystemsManager(null, new AWSOptions()), typeof(ArgumentNullException), "Parameter name: path"},
+            {builder => builder.AddSystemsManager(null, null), typeof(ArgumentNullException), "path"},
+            {builder => builder.AddSystemsManager("/path", null), typeof(ArgumentNullException), "awsOptions"},
+            {builder => builder.AddSystemsManager(null, new AWSOptions()), typeof(ArgumentNullException), "path"},
             {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue", new AWSOptions()), null, null},
             {builder => builder.AddSystemsManager("/path", new AWSOptions(), true), null, null},
             {builder => builder.AddSystemsManager("/path", new AWSOptions(), false), null, null},
@@ -67,7 +67,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
         public static TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string> NoAWSOptionsExtensionData => new TheoryData<Func<IConfigurationBuilder, IConfigurationBuilder>, Type, string>
         {
-            {builder => builder.AddSystemsManager(null as string), typeof(ArgumentNullException), "Parameter name: path"},
+            {builder => builder.AddSystemsManager(null as string), typeof(ArgumentNullException), "path"},
             {builder => builder.AddSystemsManager("/path"), null, null},
             {builder => builder.AddSystemsManager("/aws/reference/secretsmanager/somevalue"), null, null},
             {builder => builder.AddSystemsManager("/path", true), null, null},


### PR DESCRIPTION
## Description
Add AppConfig as another Systems Manager's source of configuration.

## Motivation and Context
It is extending the functionality for a new source of configuration.

## Testing
I created the ASP.NET app and configure it with AppConfig using this new extension.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
