### PR TITLE
Add AppConfig support for Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In Lambda you don't need `Host`, but you can use `ConfigurationBuilder` to retri
 
 For AppConfig in Lambda there is special implementation `AddAppConfigForLambda` which uses [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html).
 
-Very important!! If you want to use AppConfig, remember to add proper [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html) to your AWS Lambda.
+Very important!! If you want to use AppConfig, remember to add proper [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html) and required environment variables to your AWS Lambda.
 
 ```csharp
 var configurations = new ConfigurationBuilder()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ![.NET on AWS Banner](./logo.png ".NET on AWS")
 
 # AWS .NET Configuration Extension for Systems Manager
+
 [![nuget](https://img.shields.io/nuget/v/Amazon.Extensions.Configuration.SystemsManager.svg)](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/)
 
-[Amazon.Extensions.Configuration.SystemsManager](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/) simplifies using [AWS SSM's](https://aws.amazon.com/systems-manager) [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) and [AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) as a source for configuration information for .NET Core applications.  This project was contributed by [@KenHundley](https://github.com/KenHundley) and [@MichalGorski](https://github.com/mgorski-mg).
+[Amazon.Extensions.Configuration.SystemsManager](https://www.nuget.org/packages/Amazon.Extensions.Configuration.SystemsManager/) simplifies using [AWS SSM's](https://aws.amazon.com/systems-manager) [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) and [AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) as a source for configuration information for .NET Core applications. This project was contributed by [@KenHundley](https://github.com/KenHundley) and [@MichalGorski](https://github.com/mgorski-mg).
 
 The library introduces the following dependencies:
 
@@ -14,10 +15,11 @@ The library introduces the following dependencies:
 
 # Getting Started
 
-Follow the examples below to see how the library can be integrated into your application.  This extension adheres to the same practices and conventions of [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1).
+Follow the examples below to see how the library can be integrated into your application. This extension adheres to the same practices and conventions of [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1).
 
 ## ASP.NET Core Example
-One of the common use cases for this library is to pull configuration from Parameter Store.  You can easily add this functionality by adding 1 line of code.
+
+One of the common use cases for this library is to pull configuration from Parameter Store. You can easily add this functionality by adding 1 line of code.
 
 ```csharp
 public class Program
@@ -37,7 +39,7 @@ public class Program
 }
 ```
 
-Second possibility is to pull configuration from AppConfig.  You can easily add this functionality by adding 1 line of code.
+Second possibility is to pull configuration from AppConfig. You can easily add this functionality by adding 1 line of code.
 
 ```csharp
 public class Program
@@ -58,7 +60,8 @@ public class Program
 ```
 
 ## HostBuilder Example
-Microsoft introduced [.NET Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.1) to de-couple HTTP pipeline from the Web Host API.  The Generic Host library allows you to write non-HTTP services using configuration, dependency injection, and logging features.  The sample code below shows you how to use the the AWS .NET Configuration Extension library:
+
+Microsoft introduced [.NET Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.1) to de-couple HTTP pipeline from the Web Host API. The Generic Host library allows you to write non-HTTP services using configuration, dependency injection, and logging features. The sample code below shows you how to use the AWS .NET Configuration Extension library:
 
 ```csharp
 namespace HostBuilderExample
@@ -81,9 +84,9 @@ namespace HostBuilderExample
 
 ## AWS Lambda Example
 
-In Lambda you don't need `Host`, but you can use `ConfigurationBuilder` to retrieve the configuration from Parameter Store or AppConfig.
+In AWS Lambda you don't need `Host`, but you can use `ConfigurationBuilder` to retrieve the configuration from Parameter Store or AppConfig.
 
-For AppConfig in Lambda there is special implementation `AddAppConfigForLambda` which uses [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html).
+For AppConfig in AWS Lambda there is special implementation `AddAppConfigForLambda` which uses [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html).
 
 Very important!! If you want to use AppConfig, remember to add proper [Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html) and required environment variables to your AWS Lambda.
 
@@ -98,9 +101,9 @@ var configurations = new ConfigurationBuilder()
 
 The `reloadAfter` parameter on `AddSystemsManager()`, `AddAppConfig()` and `AddAppConfigForLambda()` enables automatic reloading of configuration data from Parameter Store or AppConfig as a background task.
 
-## Parameter Store config reloading in AWS Lambda
+## Config reloading from Parameter Store in AWS Lambda
 
-In AWS Lambda, background tasks are paused after processing a Lambda event. This could disrupt the provider from retrieving the latest configuration data from Parameter Store. To ensure the reload is performed within a Lambda event, we recommend calling the extension method `WaitForSystemsManagerReloadToComplete` from the `IConfiguration` object in your Lambda function. This method will immediately return unless a reload is currently being performed.
+In AWS Lambda, background tasks are paused after processing the AWS Lambda event. This could disrupt the provider from retrieving the latest configuration data from Parameter Store. To ensure the reload is performed within the AWS Lambda event, we recommend calling the extension method `WaitForSystemsManagerReloadToComplete` from the `IConfiguration` object in your AWS Lambda function. This method will immediately return unless a reload is currently being performed.
 
 ```csharp
 using Amazon.Extensions.Configuration.SystemsManager
@@ -116,9 +119,18 @@ var configurations = new ConfigurationBuilder()
 configurations.WaitForSystemsManagerReloadToComplete(TimeSpan.FromSeconds(5));
 ```
 
+## Config reloading from AppConfig in AWS Lambda
+
+Lambda Extension is automatically reloading the config with the interval set in an environment variable. Because of that you don't need to pass `reloadAfter` parameter into `AddAppConfigForLambda()` method.
+
+The possibility to pass 'reloadAfter' parameter is for a situation when you need to create `IConfiguration` in the AWS Lambda Handler class constructor to initialize other sources of configuration.
+
+In a normal situation, it is recommended to build `IConfiguration` in the AWS Lambda Invoke method. This approach allows you to always have fresh config from Lambda Extension in every AWS Lambda invocation. There is no invocation time cost because building `IConfiguration` takes few milliseconds when the config is already present in Lambda Extension.
+
 ## Samples
 
 ### Custom ParameterProcessor Sample
+
 Example of using a custom `IParameterProcessor` which provides a way to store and retrieve `null` values. Since AWS Parameter Store params are string literals, there is no way to store a `null` value by default.
 
 ```csharp
@@ -160,24 +172,24 @@ For more complete examples, take a look at sample projects available in [samples
 
 # Configuring Systems Manager Client
 
-This extension is using [AWSSDK.Extensions.NETCore.Setup](https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup/) in order to get AWSOptions from `Configuration` object and create AWS Systems Manager Client. You can edit and override the configuration by adding AWSOptions to your configuration providers such as appsettings.Development.json. Below is an example of a configuration provider:
+This extension is using [AWSSDK.Extensions.NETCore.Setup](https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup/) to get AWSOptions from `Configuration` object and create AWS Systems Manager Client. You can edit and override the configuration by adding AWSOptions to your configuration providers such as appsettings.Development.json. Below is an example of a configuration provider:
 
 ```JSON
 {
-...
+  ...
 
   "AWS": {
     "Profile": "default",
     "Region": "us-east-1",
     "ResignRetries": true
   }
-  
-...
+
+  ...
 }
 ```
- 
- For more information and other configurable options please refer to [Configuring the AWS SDK for .NET with .NET Core](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html).
- 
+
+For more information and other configurable options please refer to [Configuring the AWS SDK for .NET with .NET Core](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html).
+
 # Getting Help
 
 We use the [GitHub issues](https://github.com/aws/aws-dotnet-extensions-configuration/issues) for tracking bugs and feature requests and have limited bandwidth to address them.
@@ -187,8 +199,7 @@ If you think you may have found a bug, please open an [issue](https://github.com
 # Contributing
 
 We welcome community contributions and pull requests. See
-[CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to set up a development
-environment and submit code.
+[CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to set up a development environment and submit code.
 
 # Additional Resources
 
@@ -196,7 +207,7 @@ environment and submit code.
 GitHub home for .NET development on AWS. You'll find libraries, tools, and resources to help you build .NET applications and services on AWS.
 
 [AWS Developer Center - Explore .NET on AWS](https://aws.amazon.com/developer/language/net/)  
-Find all the .NET code samples, step-by-step guides, videos, blog content, tools, and information about live events that you need in one place. 
+Find all the .NET code samples, step-by-step guides, videos, blog content, tools, and information about live events that you need in one place.
 
 [AWS Developer Blog - .NET](https://aws.amazon.com/blogs/developer/category/programing-language/dot-net/)  
 Come see what .NET developers at AWS are up to!  Learn about new .NET software announcements, guides, and how-to's.
@@ -206,6 +217,6 @@ Follow us on twitter!
 
 # License
 
-Libraries in this repository are licensed under the Apache 2.0 License. 
+Libraries in this repository are licensed under the Apache 2.0 License.
 
 See [LICENSE](./LICENSE) and [NOTICE](./NOTICE) for more information.

--- a/samples/Lambda/Assemby.cs
+++ b/samples/Lambda/Assemby.cs
@@ -1,0 +1,5 @@
+﻿using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]

--- a/samples/Lambda/Configuration/AwsAppConfigConfiguration.cs
+++ b/samples/Lambda/Configuration/AwsAppConfigConfiguration.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Lambda.Configuration
+{
+    public class AwsAppConfigConfiguration
+    {
+        public readonly string ApplicationId;
+        public readonly string EnvironmentId;
+        public readonly string ConfigProfileId;
+        public readonly TimeSpan? ConfigReloadTime;
+
+        private AwsAppConfigConfiguration(string applicationId, string environmentId, string configProfileId, TimeSpan? configReloadTime)
+        {
+            ApplicationId = applicationId;
+            EnvironmentId = environmentId;
+            ConfigProfileId = configProfileId;
+            ConfigReloadTime = configReloadTime;
+        }
+
+        public static AwsAppConfigConfiguration GetFromEnvironmentVariables()
+        {
+            var reloadTimeInSeconds = Environment.GetEnvironmentVariable("AppConfigReloadTimeInSeconds");
+            var reloadTime = reloadTimeInSeconds == null ? (TimeSpan?) null : TimeSpan.FromSeconds(int.Parse(reloadTimeInSeconds));
+
+            return new AwsAppConfigConfiguration(
+                Environment.GetEnvironmentVariable("AppConfigAppId")!,
+                Environment.GetEnvironmentVariable("AppConfigEnvironmentId")!,
+                Environment.GetEnvironmentVariable("AppConfigConfigProfileId")!,
+                reloadTime
+            );
+        }
+    }
+}

--- a/samples/Lambda/Configuration/ConfigurationReader.cs
+++ b/samples/Lambda/Configuration/ConfigurationReader.cs
@@ -1,0 +1,32 @@
+using System;
+using Amazon.Extensions.Configuration.SystemsManager;
+using Microsoft.Extensions.Configuration;
+
+namespace Lambda.Configuration
+{
+    public static class ConfigurationReader
+    {
+        private static IConfigurationRoot config;
+
+        public static void Init()
+        {
+            var appConfig = AwsAppConfigConfiguration.GetFromEnvironmentVariables();
+            config = new ConfigurationBuilder()
+                    .AddEnvironmentVariables()
+                    .AddAppConfigForLambda(appConfig.ApplicationId, appConfig.EnvironmentId, appConfig.ConfigProfileId, appConfig.ConfigReloadTime)
+                    .Build();
+        }
+
+        public static void EnsureConfigurationIsReloaded()
+        {
+            config.WaitForSystemsManagerReloadToComplete(TimeSpan.FromSeconds(2));
+        }
+
+        public static TestParameters GetTestParameters()
+        {
+            var testParameters = new TestParameters();
+            config.GetSection("TestParameters").Bind(testParameters);
+            return testParameters;
+        }
+    }
+}

--- a/samples/Lambda/Configuration/TestParameters.cs
+++ b/samples/Lambda/Configuration/TestParameters.cs
@@ -1,0 +1,8 @@
+
+namespace Lambda.Configuration
+{
+    public class TestParameters
+    {
+        public string TestParam { get; set; }
+    }
+}

--- a/samples/Lambda/Functions/ConfigLambda.cs
+++ b/samples/Lambda/Functions/ConfigLambda.cs
@@ -1,0 +1,23 @@
+using System;
+using Amazon.XRay.Recorder.Handlers.AwsSdk;
+using Lambda.Configuration;
+
+namespace Lambda.Functions
+{
+    public class ConfigLambda
+    {
+        public ConfigLambda()
+        {
+            AWSSDKHandler.RegisterXRayForAllServices();
+            ConfigurationReader.Init();
+        }
+
+        protected void Invoke()
+        {
+            ConfigurationReader.EnsureConfigurationIsReloaded();
+
+            var testParameters = ConfigurationReader.GetTestParameters();
+            Console.WriteLine($"TestParam: {testParameters.TestParam}");
+        }
+    }
+}

--- a/samples/Lambda/Lambda.csproj
+++ b/samples/Lambda/Lambda.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+        <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Amazon.Extensions.Configuration.SystemsManager\Amazon.Extensions.Configuration.SystemsManager.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/samples/Lambda/application.yaml
+++ b/samples/Lambda/application.yaml
@@ -66,3 +66,5 @@ Globals:
         AppConfigReloadTimeInSeconds: 90
         AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: 60
         AWS_APPCONFIG_EXTENSION_HTTP_PORT: 2772
+        AWS_APPCONFIG_EXTENSION_LOG_LEVEL: debug
+        AWS_APPCONFIG_EXTENSION_PREFETCH_LIST: !Sub /applications/${AppConfigApplication}/environments/${AppConfigEnvironment}/configurations/${AppConfigConfigurationProfile}

--- a/samples/Lambda/application.yaml
+++ b/samples/Lambda/application.yaml
@@ -1,0 +1,68 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  ConfigLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: Lambda::Lambda.Functions.ConfigLambda::Invoke
+      Role: !GetAtt ConfigLambdaRole.Arn
+
+  ConfigLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Policies:
+        - PolicyName: allowToUseAppConfig
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: appconfig:GetConfiguration
+                Resource:
+                  - !Sub arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}
+                  - !Sub arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}/environment/${AppConfigEnvironment}
+                  - !Sub arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}/configurationprofile/${AppConfigConfigurationProfile}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+
+  AppConfigApplication:
+    Type: AWS::AppConfig::Application
+    Properties:
+      Name: !Ref AWS::StackName
+
+  AppConfigEnvironment:
+    Type: AWS::AppConfig::Environment
+    Properties:
+      ApplicationId: !Ref AppConfigApplication
+      Name: config
+
+  AppConfigConfigurationProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplication
+      Name: config-profile
+      LocationUri: hosted
+
+Globals:
+  Function:
+    Runtime: dotnetcore3.1
+    CodeUri: bin/Release/netcoreapp3.1/publish
+    MemorySize: 128
+    Timeout: 30
+    Tracing: Active
+    Layers:
+      - arn:aws:lambda:eu-west-1:434848589818:layer:AWS-AppConfig-Extension:41
+    Environment:
+      Variables:
+        AppConfigAppId: !Ref AppConfigApplication
+        AppConfigEnvironmentId: !Ref AppConfigEnvironment
+        AppConfigConfigProfileId: !Ref AppConfigConfigurationProfile
+        AppConfigReloadTimeInSeconds: 90
+        AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: 60
+        AWS_APPCONFIG_EXTENSION_HTTP_PORT: 2772

--- a/samples/Lambda/deploy.ps1
+++ b/samples/Lambda/deploy.ps1
@@ -1,5 +1,6 @@
 dotnet lambda deploy-serverless `
     --configuration Release `
+    --region eu-west-1 `
     --stack-name configuration-lambda `
     --s3-bucket [s3-bucket-name] `
     --s3-prefix configuration-sample/lambda/ `

--- a/samples/Lambda/deploy.ps1
+++ b/samples/Lambda/deploy.ps1
@@ -1,0 +1,6 @@
+dotnet lambda deploy-serverless `
+    --configuration Release `
+    --stack-name configuration-lambda `
+    --s3-bucket [s3-bucket-name] `
+    --s3-prefix configuration-sample/lambda/ `
+    --template application.yaml;

--- a/samples/Samples.sln
+++ b/samples/Samples.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Extensions.Configura
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples", "Samples\Samples.csproj", "{74F8A828-62EB-4338-A106-F28D91FE4B3A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lambda", "Lambda\Lambda.csproj", "{3CDAAA19-18CD-4852-9A1B-355B4182C3B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{74F8A828-62EB-4338-A106-F28D91FE4B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74F8A828-62EB-4338-A106-F28D91FE4B3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74F8A828-62EB-4338-A106-F28D91FE4B3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CDAAA19-18CD-4852-9A1B-355B4182C3B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CDAAA19-18CD-4852-9A1B-355B4182C3B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CDAAA19-18CD-4852-9A1B-355B4182C3B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CDAAA19-18CD-4852-9A1B-355B4182C3B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -44,9 +44,9 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AppConfig" Version="3.7.0.52" />
+    <PackageReference Include="AWSSDK.AppConfig" Version="3.7.0.54" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.4.11" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
   </ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -44,9 +44,9 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AppConfig" Version="3.7.0.54" />
+    <PackageReference Include="AWSSDK.AppConfig" Version="3.7.0.61" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.5" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.5.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
   </ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Extensions.Configuration
     {
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -54,6 +56,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -78,6 +82,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -102,6 +108,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -125,6 +133,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -147,6 +157,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -168,6 +180,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -189,6 +203,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -209,6 +225,8 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// If you want to use AWS AppConfig with AWS Lambda, consider to use AddAppConfigForLambda method. It is designed to work with AWS Lambda Extension.
+        /// But if you really need to use this method with AWS Lambda, remember that to use AWS AppConfig caching mechanism properly, you need to build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="source">Configuration source.</param>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -58,6 +59,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -84,6 +86,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -110,6 +113,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -135,6 +139,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -159,6 +164,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -182,6 +188,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -205,6 +212,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
@@ -227,6 +235,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
         /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
+        /// To use AWS AppConfig caching mechanism properly, always build <see cref="IConfiguration"/> in the AWS Lambda constructor. Thanks to that <see cref="SystemsManagerConfigurationProvider"/> can use ClientId and remember Last Configuration version.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="source">Configuration source.</param>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
@@ -1,0 +1,280 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Extensions.Configuration.SystemsManager;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Amazon.Extensions.Configuration.SystemsManager.Internal;
+using Amazon.Extensions.NETCore.Setup;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Extension methods for registering <see cref="SystemsManagerConfigurationProvider"/> with <see cref="IConfigurationBuilder"/>.
+    /// </summary>
+    public static class AppConfigForLambdaExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, bool optional, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, optional, reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, bool optional)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, optional));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, AWSOptions awsOptions)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+            if (awsOptions == null) throw new ArgumentNullException(nameof(awsOptions));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, awsOptions));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, bool optional, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, optional: optional, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, TimeSpan? reloadAfter)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, reloadAfter: reloadAfter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId, bool optional)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId, optional: optional));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="applicationId">The AppConfig application id.</param>
+        /// <param name="environmentId">The AppConfig environment id.</param>
+        /// <param name="configProfileId">The AppConfig configuration profile id.</param>
+        /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, string applicationId, string environmentId, string configProfileId)
+        {
+            if (applicationId == null) throw new ArgumentNullException(nameof(applicationId));
+            if (environmentId == null) throw new ArgumentNullException(nameof(environmentId));
+            if (configProfileId == null) throw new ArgumentNullException(nameof(configProfileId));
+
+            return builder.AddAppConfigForLambda(ConfigureSource(applicationId, environmentId, configProfileId));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
+        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// Remember to add proper Layer to your AWS Lambda.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="source">Configuration source.</param>
+        /// <exception cref="ArgumentNullException"><see cref="source"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.ApplicationId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.EnvironmentId"/> cannot be null</exception>
+        /// <exception cref="ArgumentNullException"><see cref="source"/>.<see cref="AppConfigConfigurationSource.ConfigProfileId"/> cannot be null</exception>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAppConfigForLambda(this IConfigurationBuilder builder, AppConfigConfigurationSource source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (source.ApplicationId == null) throw new ArgumentNullException(nameof(source.ApplicationId));
+            if (source.EnvironmentId == null) throw new ArgumentNullException(nameof(source.EnvironmentId));
+            if (source.ConfigProfileId == null) throw new ArgumentNullException(nameof(source.ConfigProfileId));
+            if (source.ClientId == null) throw new ArgumentNullException(nameof(source.ClientId));
+
+            if (source.AwsOptions == null)
+            {
+                source.AwsOptions = AwsOptionsProvider.GetAwsOptions(builder);
+            }
+
+            if (string.IsNullOrWhiteSpace(source.AwsOptions.DefaultClientConfig.ServiceURL))
+            {
+                source.AwsOptions.DefaultClientConfig.ServiceURL = "http://localhost:2772";
+            }
+
+            return builder.Add(source);
+        }
+
+        private static AppConfigConfigurationSource ConfigureSource(
+            string applicationId,
+            string environmentId,
+            string configProfileId,
+            AWSOptions awsOptions = null,
+            bool optional = false,
+            TimeSpan? reloadAfter = null
+        )
+        {
+            return new AppConfigConfigurationSource
+            {
+                ApplicationId = applicationId,
+                EnvironmentId = environmentId,
+                ConfigProfileId = configProfileId,
+                ClientId = Guid.NewGuid().ToString(),
+                AwsOptions = awsOptions,
+                Optional = optional,
+                ReloadAfter = reloadAfter
+            };
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigForLambdaExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Configuration
     {
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="configProfileId">The AppConfig configuration profile id.</param>
         /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
         /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
-        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan. Only needed when you are calling this method in the AWS Lambda Handler class constructor.</param>
         /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="environmentId">The AppConfig environment id.</param>
         /// <param name="configProfileId">The AppConfig configuration profile id.</param>
         /// <param name="awsOptions"><see cref="AWSOptions"/> used to create an AWS Systems Manager AppConfig Client connection</param>
-        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan. Only needed when you are calling this method in the AWS Lambda Handler class constructor.</param>
         /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="environmentId">The AppConfig environment id.</param>
         /// <param name="configProfileId">The AppConfig configuration profile id.</param>
         /// <param name="optional">Whether the AWS Systems Manager AppConfig is optional.</param>
-        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan. Only needed when you are calling this method in the AWS Lambda Handler class constructor.</param>
         /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
@@ -157,14 +157,14 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="applicationId">The AppConfig application id.</param>
         /// <param name="environmentId">The AppConfig environment id.</param>
         /// <param name="configProfileId">The AppConfig configuration profile id.</param>
-        /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
+        /// <param name="reloadAfter">Initiate reload after TimeSpan. Only needed when you are calling this method in the AWS Lambda Handler class constructor.</param>
         /// <exception cref="ArgumentNullException"><see cref="applicationId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="environmentId"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="configProfileId"/> cannot be null</exception>
@@ -180,7 +180,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -203,7 +203,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -225,7 +225,7 @@ namespace Microsoft.Extensions.Configuration
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from AWS Systems Manager AppConfig.
-        /// For Lambda it uses Lambda Layer to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
+        /// For AWS Lambda it uses Lambda Extension to retrieve config according to the <a href="https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html">documentation</a>.
         /// Remember to add proper Layer to your AWS Lambda.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
@@ -59,7 +59,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
 
                 var response = await client.GetConfigurationAsync(request).ConfigureAwait(false);
 
-                if (response.ContentLength > 0)
+                if (response.ConfigurationVersion != LastConfigVersion)
                 {
                     LastConfigVersion = response.ConfigurationVersion;
                     LastConfig = ParseConfig(response);

--- a/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/ConfigurationExtensions.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Configuration;
 namespace Amazon.Extensions.Configuration.SystemsManager
 {
     /// <summary>
-    /// This extension is an a different namespace to avoid misuse of this method which should only be called when being used from Lambda.
+    /// This extension is an a different namespace to avoid misuse of this method which should only be called when being used from AWS Lambda.
     /// </summary>
     public static class ConfigurationExtensions
     {
@@ -27,13 +27,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// This method blocks while any SystemsManagerConfigurationProvider added to IConfiguration are
         /// currently reloading the parameters from Parameter Store.
         /// 
-        /// This is generally only needed when the provider is being called from a Lambda function. Without this call
-        /// in a Lambda environment there is a potential of the background thread doing the refresh never running successfully.
-        /// This can happen because the Lambda compute environment is frozen after the current Lambda event is complete.
+        /// This is generally only needed when the provider is being called from a AWS Lambda function. Without this call
+        /// in a AWS Lambda environment there is a potential of the background thread doing the refresh never running successfully.
+        /// This can happen because the AWS Lambda compute environment is frozen after the current AWS Lambda event is complete.
         /// </summary>
         /// <param name="configuration"></param>
-        /// <param name="timeSpan"></param>
-        public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeSpan)
+        /// <param name="timeout">Maximum time to wait for reload to be completed</param>
+        public static void WaitForSystemsManagerReloadToComplete(this IConfiguration configuration, TimeSpan timeout)
         {
             if (configuration is ConfigurationRoot configRoot)
             {
@@ -41,7 +41,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                 {
                     if (provider is SystemsManagerConfigurationProvider ssmProvider)
                     {
-                        ssmProvider.WaitForReloadToComplete(timeSpan);
+                        ssmProvider.WaitForReloadToComplete(timeout);
                     }
                 }
             }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -91,8 +91,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         /// If this configuration provider is currently performing a reload of the config data this method will block until
         /// the reload is called.
         /// 
-        /// This method is not meant for general use. It is exposed so a Lambda function can wait for the reload to complete
-        /// before completing the event causing the Lambda compute environment to be frozen.
+        /// This method is not meant for general use. It is exposed so a AWS Lambda function can wait for the reload to complete
+        /// before completing the event causing the AWS Lambda compute environment to be frozen.
         /// </summary>
         public void WaitForReloadToComplete(TimeSpan timeout)
         {

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.44" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Integ/Amazon.Extensions.Configuration.SystemsManager.Integ.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.44" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.51" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/Amazon.Extensions.Configuration.SystemsManager.Tests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigForLambdaExtensionsTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigForLambdaExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class AppConfigForLambdaExtensionsTests
+    {
+        [Fact]
+        public void AddAppConfigForLambdaWithProperInputShouldReturnProperConfigurationBuilder()
+        {
+            var expectedBuilder = new ConfigurationBuilder();
+            expectedBuilder.Sources.Add(new Mock<AppConfigConfigurationSource>().Object);
+            const string applicationId = "appId";
+            const string environmentId = "envId";
+            const string configProfileId = "profId";
+            const string configServiceUrl = "http://localhost:2772";
+
+            var builder = new ConfigurationBuilder();
+            builder.AddAppConfigForLambda(applicationId, environmentId, configProfileId);
+
+            Assert.Contains(
+                builder.Sources,
+                source => source is AppConfigConfigurationSource configurationSource
+                       && configurationSource.ApplicationId == applicationId
+                       && configurationSource.EnvironmentId == environmentId
+                       && configurationSource.ConfigProfileId == configProfileId
+                       && configurationSource.AwsOptions.DefaultClientConfig.ServiceURL == configServiceUrl
+            );
+        }
+
+        [Fact]
+        public void AddAppConfigForLambdaWithoutAwsOptionsShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfigForLambda("appId", "envId", "profileId", awsOptions: null);
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("awsOptions", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigForLambdaWithoutApplicationIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfigForLambda(null, "envId", "profileId");
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("applicationId", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigForLambdaWithoutEnvironmentIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfigForLambda("appId", null, "profileId");
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("environmentId", ex.Message);
+        }
+
+        [Fact]
+        public void AddAppConfigForLambdaWithoutProfileIdShouldThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            Func<IConfigurationBuilder> func = () => builder.AddAppConfigForLambda("appId", "envId", null);
+
+            var ex = Assert.Throws<ArgumentNullException>(func);
+            Assert.Contains("configProfileId", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add AWS AppConfig support for AWS Lambda. This functionality uses Lambda Extension to retrieve the config.

## Motivation and Context
It is extending the AWS AppConfig functionality to support AWS Lambdas properly.

## Testing
I created the AWS Lambda app and configure it with AppConfig using this new extension.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license