### PR TITLE
support retrieving a single parameter by name

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/SystemsManagerProcessor.cs
@@ -33,17 +33,18 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
         {
             if (source.AwsOptions == null) throw new ArgumentNullException(nameof(source.AwsOptions));
             if (source.Path == null) throw new ArgumentNullException(nameof(source.Path));
-            
+
             Source = source;
+            Source.SingleParameter = IsSecretsManagerPath(Source.Path) || Source.SingleParameter;
             Source.ParameterProcessor = Source.ParameterProcessor ??
-                (IsSecretsManagerPath(Source.Path)
+                (Source.SingleParameter
                     ? new JsonParameterProcessor()
                     : new DefaultParameterProcessor());
         }
 
         public async Task<IDictionary<string, string>> GetDataAsync()
         {
-            return IsSecretsManagerPath(Source.Path)
+            return Source.SingleParameter
                 ? await GetParameterAsync().ConfigureAwait(false)
                 : await GetParametersByPathAsync().ConfigureAwait(false);
         }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationSource.cs
@@ -38,6 +38,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         public string Path { get; set; }
 
         /// <summary>
+        /// True to use the GetParameter action to retrieve a single parameter by name.
+        /// False to use the GetParametersByPath action to retrieve all parameters under a path hierarchy.
+        /// Always true if <see cref="Path"/> is a Secrets Manager path. Defaults to false otherwise.
+        /// </summary>
+        public bool SingleParameter { get; set; }
+
+        /// <summary>
         /// <see cref="AWSOptions"/> used to create an AWS Systems Manager Client />.
         /// </summary>
         public AWSOptions AwsOptions { get; set; }
@@ -57,7 +64,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager
         public Action<SystemsManagerExceptionContext> OnLoadException { get; set; }
 
         /// <summary>
-        /// Implementation of <see cref="IParameterProcessor"/> used to process <see cref="Parameter"/> results. Defaults to <see cref="DefaultParameterProcessor"/>.
+        /// Implementation of <see cref="IParameterProcessor"/> used to process <see cref="Parameter"/> results.
+        /// Defaults to <see cref="JsonParameterProcessor"/> if <see cref="SingleParameter"/> is true, otherwise defaults to <see cref="DefaultParameterProcessor"/>.
         /// </summary>
         public IParameterProcessor ParameterProcessor { get; set; }
 


### PR DESCRIPTION
## Description

Add `SingleParameter` property to `SystemsManagerConfigurationSource`, which can be used to generalize the current behaviour for Secrets Manager paths:

* when set to true, use `ssm:GetParameter` to retrieve a single parameter, and use `JsonParameterProcessor` by default.
* always true for Secrets Manager path. (Secrets Manager path effectively becomes a special case of `SingleParameter = true`).
* defaults to false (for non-Secrets Manager path of course), and still use `DefaultParameterProcessor`. So no breaking changes for existing usage.

Targets/based on #103.

## Motivation and Context

closes #47

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
