### PR TITLE
Fixed ValuesController doesn't show correct values from Parameter Store issue

### DIFF
--- a/samples/Samples/Program.cs
+++ b/samples/Samples/Program.cs
@@ -2,6 +2,7 @@
 using Amazon.Extensions.NETCore.Setup;
 using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
+using Samples;
 
 //populates some sample data to be used by this example project
 await PopulateSampleDataForThisProject().ConfigureAwait(false);
@@ -9,6 +10,8 @@ await PopulateSampleDataForThisProject().ConfigureAwait(false);
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddSystemsManager($"/dotnet-aws-samples/systems-manager-sample/");
+
+builder.Services.Configure<Settings>(builder.Configuration.GetSection($"common:settings"));
 
 // Add services to the container.
 builder.Services.AddControllers();


### PR DESCRIPTION
Fixed ValuesController doesn't show correct values from Parameter Store issue.
<!--- Provide a general summary of your changes in the Title above -->

## Description
"Samples" project missed one line of code for configuring "Settings" from configuration section, which caused that "ValuesController" didn't show correct values from AWS Parameter Store.

## Motivation and Context
Details can be found in - https://github.com/aws/aws-dotnet-extensions-configuration/issues/114

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
