### PR TITLE
Update AppConfig IAM requirements in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,7 @@ If the application reads configuration values from AWS Systems Manager AppConfig
         "appconfig:StartConfigurationSession",
         "appconfig:GetLatestConfiguration",
       ],
-      "Resource": [
-          "arn:${Partition}:appconfig:${Region}:${Account}:application/${ApplicationId}",
-          "arn:${Partition}:appconfig:${Region}:${Account}:application/${ApplicationId}/environment/${EnvironmentId}",
-          "arn:${Partition}:appconfig:${Region}:${Account}:application/${ApplicationId}/configurationprofile/${ConfigurationProfileId}"
-      ]
+      "Resource": "arn:${Partition}:appconfig:${Region}:${Account}:application/${ApplicationId}/environment/${EnvironmentId}/configuration/${ConfigurationProfileId}"
     }
   ]
 }


### PR DESCRIPTION
Update AppConfig IAM requirements in Readme

## Description
Only one resource is necessary for AppConfig in the IAM Role

## Motivation and Context
Fix Readme

## Testing
Validated on my personal stack.

## Types of changes
Just a readme change.

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement