### PR TITLE
update readme with .net lambda serverless api config info

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ This extension is using [AWSSDK.Extensions.NETCore.Setup](https://www.nuget.org/
 }
 ```
 
+
+### With AWS Lambda Serverless Api .Net Template
+
+When using .Net Lambda Serverless Api Template the default appsettings.Development.json contain a AWS section with a region set to **DefaultRegion**, this make Configuration Extension for Systems Manager unable to start with a host issue (No such host is known). Remove this section or put a real aws region to make it work.
+
 For more information and other configurable options please refer to [Configuring the AWS SDK for .NET with .NET Core](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html).
 
 # Permissions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add informations in the readme to make work Amazon.Extensions.Configuration.SystemsManager in case of use .net lambda Serverless template

## Motivation and Context
When using Amazon.Extensions.Configuration.SystemsManager with .net lambda serverless template, default configuration cause configuration conflict and the Amazon.Extensions.Configuration.SystemsManager make the app crash. With these information in the readme, it's simple to make it work.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
