### PR TITLE
fix: Only attempt to parse the AppConfig response when it is not empty

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigProcessor.cs
@@ -124,7 +124,12 @@ namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
                     PollConfigurationToken = response.NextPollConfigurationToken;
                     NextAllowedPollTime = DateTime.UtcNow.AddSeconds(response.NextPollIntervalInSeconds);
 
-                    LastConfig = ParseConfig(response.ContentType, response.Configuration);
+                    // Configuration is empty when the last received config is the latest
+                    // so only attempt to parse the AppConfig response when it is not empty
+                    if (response.ContentLength > 0)
+                    {
+                        LastConfig = ParseConfig(response.ContentType, response.Configuration);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
## Description
Based on the [API documentation](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_appconfigdata_GetLatestConfiguration.html#API_appconfigdata_GetLatestConfiguration_ResponseElements), the call to AppConfig `GetLatestConfigurationAsync` will return an empty response when the configuration has not changed.  This PR fixes a thrown Json parsing exception due to that empty response.

## Motivation and Context
The periodic refresh was frequently throwing a `JsonReaderException` because the empty response could not be parsed as valid json.

## Testing
Tested existing functionality by running unit and integration tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
