### PR TITLE
Fixed JsonParameterProcessor to separate parameters retrieved with part of Path.

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>4.0.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
@@ -23,13 +23,17 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 new Parameter {Name = "/p1/p3", Value = "{\"p3key\": \"p3value\"}"},
                 new Parameter {Name = "/p4", Value = "{\"p4key\": { \"p5key\": \"p5value\" } }"},
                 new Parameter {Name = "/p6", Value = "{\"p6key\": { \"p7key\": { \"p8key\": \"p8value\" } } }"},
+                new Parameter {Name = "/ObjectA", Value = "{\"Bucket\": \"arnA\"}"},
+                new Parameter {Name = "/ObjectB", Value = "{\"Bucket\": \"arnB\"}"}
             };
             var expected = new Dictionary<string, string>() {
-                { "p1", "p1" },
-                { "p2", "p2" },
-                { "p3key", "p3value" },
-                { "p4key:p5key", "p5value" },
-                { "p6key:p7key:p8key", "p8value" },
+                { "p1:p1", "p1" },
+                { "p2:p2", "p2" },
+                { "p1:p3:p3key", "p3value" },
+                { "p4:p4key:p5key", "p5value" },
+                { "p6:p6key:p7key:p8key", "p8value" },
+                { "ObjectA:Bucket", "arnA" },
+                { "ObjectB:Bucket", "arnB" }
             };
 
             const string path = "/";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed `JsonParameterProcessor` to separate parameters retrieved with part of Path.
- The `DefaultParameterProcessor` has logic to create keys if `Path` is the subset of the parameter name. For instance, if there are 2 System Manager Parameters `/release/api/ObjectA` with value `valueA` and `/release/api/ObjectB` with value `valueB`, the configuration to retrieve parmaters by path `/release/api` via `DefaultParameterProcessor` would configure 2 parameters with keys `ObjectA` and `ObjectB` respectively.
- However, the `JsonParameterProcessor`, which inherits from `DefaultParameterProcessor`, only processes parameter JSON value. Taking customer's scenario:
  - It only processes JSON values `{ "Bucket": "arnA" }` and `{ "Bucket": "arnB" }` for the parameters. This results in duplicate key exception when converting the processed values to `Dictionary`.
  - It does not prepends the keys with `ObjectA` and `ObjectB` with key delimiter `:`.
- Unit test for `JsonParameterProcessor` also handles the logic that assumes processing of just value. It does not cover customer's scenario with unique parameter name, with path queried from subset of name.
- The `JsonParameterProcessor` for complex object, for example `{ "Bucket": "arnA", "Test": { "subkey": "subvalue"} }`, dumps the following keys to dictionary: `Bucket:arnA` and `Test:subkey:subvalue`. This appears to conform to .NET Core `appSettings` hierarchy. Hence, the change in the PR appears to be correct.

**NOTE (for reviewer):** The library is version bumped to `5.0.0` since it introduces breaking change to include path hierarchy after the queried path instead of just the `JsonParameterProcessor` processed parameter values.

## Motivation and Context
GitHub issue: https://github.com/aws/aws-dotnet-extensions-configuration/issues/123

## Testing
- Tested locally.
- Ran unit test before modification to see it fail.
- Ran unit test per new logic to see it pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
