### PR TITLE
Fixed an issue where JsonParameterProcessor was prefixing : character to parameter properties while retrieving parameter by name.

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/JsonParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/JsonParameterProcessor.cs
@@ -39,7 +39,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                 var parameterDictionary = JsonConfigurationParser.Parse(parameter.Value);
                 foreach (var keyValue in parameterDictionary)
                 {
-                    string key = ConfigurationPath.Combine(prefix, keyValue.Key);
+                    string key = (!string.IsNullOrEmpty(prefix) ? ConfigurationPath.Combine(prefix, keyValue.Key) : keyValue.Key);
                     outputDictionary.Add(key, keyValue.Value);
                 }
             }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
@@ -24,7 +24,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 new Parameter {Name = "/p4", Value = "{\"p4key\": { \"p5key\": \"p5value\" } }"},
                 new Parameter {Name = "/p6", Value = "{\"p6key\": { \"p7key\": { \"p8key\": \"p8value\" } } }"},
                 new Parameter {Name = "/ObjectA", Value = "{\"Bucket\": \"arnA\"}"},
-                new Parameter {Name = "/ObjectB", Value = "{\"Bucket\": \"arnB\"}"}
+                new Parameter {Name = "/ObjectB", Value = "{\"Bucket\": \"arnB\"}"},
+                new Parameter {Name = "/", Value = "{\"testParam\": \"testValue\"}"}
             };
             var expected = new Dictionary<string, string>() {
                 { "p1:p1", "p1" },
@@ -33,7 +34,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
                 { "p4:p4key:p5key", "p5value" },
                 { "p6:p6key:p7key:p8key", "p8value" },
                 { "ObjectA:Bucket", "arnA" },
-                { "ObjectB:Bucket", "arnB" }
+                { "ObjectB:Bucket", "arnB" },
+                { "testParam", "testValue" }
             };
 
             const string path = "/";


### PR DESCRIPTION
## Description
Fixed an issue where JsonParameterProcessor was prefixing : character to parameter properties while retrieving parameter by name.

## Motivation and Context
Github issue https://github.com/aws/aws-dotnet-extensions-configuration/issues/133

## Testing
Tested locally, updated unit test.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
