### PR TITLE
feat: StringList handling in default parameter processor

### DIFF
--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
 using Moq;
 using Xunit;
@@ -32,6 +33,28 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
         }
 
+        [Fact]
+        public void ProcessParametersStringListTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/string-list/single", Value = "p1", Type = ParameterType.StringList},
+                new Parameter {Name = "/string-list/multiple", Value = "p1,p2,p3", Type = ParameterType.StringList},
+                new Parameter {Name = "/string-list/empty", Value = "", Type = ParameterType.StringList},
+            };
+
+            const string path = "/string-list";
+
+            var data = _parameterProcessor.ProcessParameters(parameters, path);
+
+            Assert.Equal("p1", data["single:0"]);
+            Assert.Equal("p1", data["multiple:0"]);
+            Assert.Equal("p2", data["multiple:1"]);
+            Assert.Equal("p3", data["multiple:2"]);
+            Assert.Equal("", data["empty:0"]);
+        }
+
+        
         [Fact]
         public void ProcessParametersRootTest()
         {

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
@@ -47,6 +47,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
             var data = _parameterProcessor.ProcessParameters(parameters, path);
 
+            Assert.Equal(5, data.Keys.Count);
             Assert.Equal("p1", data["single:0"]);
             Assert.Equal("p1", data["multiple:0"]);
             Assert.Equal("p2", data["multiple:1"]);


### PR DESCRIPTION
## Description
Add handling for StringList parameters, which is a type of parameter, supported by AWS SSM

## Motivation and Context
This addresses https://github.com/aws/aws-dotnet-extensions-configuration/issues/48

## Testing
I have run unit and integration tests and used this code in my project

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/20193278/234904773-8b768890-6c00-4d9e-8387-a097611fdc18.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

While tests are passing, I think whoever is using `DefaultParameterProcessor` won't expect that `StringList` are now handled differently. However, I would expect that one of only three SSM parameters type would convert to collection automatically.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

Not sure that this feature fits the current test structure, but old tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
