### PR TITLE
FIX ISSUE : IF Duplicate SSM parameter with different Case cause the whole SSM parameter fail to load

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
@@ -50,8 +50,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                 {
                     Key = GetKey(parameter, path),
                     Value = GetValue(parameter, path)
-                })
-                .ToDictionary(parameter => parameter.Key, parameter => parameter.Value, StringComparer.OrdinalIgnoreCase);
+                })                
+                .GroupBy(parameter => parameter.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First().Value, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/TolerantDefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/TolerantDefaultParameterProcessor.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.SimpleSystemsManagement.Model;
+
+namespace Amazon.Extensions.Configuration.SystemsManager
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// This implementation will ignore any dublicate parameters that may located in SSM with different CASE (like \Path1\Param1 and \path1\param1 , only first one will be taken).
+    /// This is based on Default parameter processor which is based on Systems Manager's suggested naming convention
+    /// </summary>
+    public class TolerantDefaultParameterProcessor : DefaultParameterProcessor
+    {
+        public override IDictionary<string, string> ProcessParameters(IEnumerable<Parameter> parameters, string path)
+        {
+            return parameters
+                .Where(parameter => IncludeParameter(parameter, path))
+                .Select(parameter => new
+                {
+                    Key = GetKey(parameter, path),
+                    Value = GetValue(parameter, path)
+                })                
+                .GroupBy(parameter => parameter.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First().Value, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Fix issue #146 -  SSM parameter case senstive but dotnet config is not, so if we have duplicate SSM parameters  with different case, it will not load the ssm params at all.

## Description
Fix issue (edge case), if we have duplicate SSM parameters  with different case (like /param/one and /Param/ONE) like below parameter, the whole SSM parameters not added to the config at all, and it's completely ignored with no error message or log.

- /Connection/OracleConnection
- /Connection/ORACLECONNECTION
- /connection/oracleconnection

## Motivation and Context
this is fix an open issue with name "Duplicate SSM parameter with different Case cause the whole SSM parameter fail to load"

## Testing
Before fix, create below SSM parameters
- /Connection/OracleConnection
- /Connection/ORACLECONNECTION
- /Connection/anyOtherParam

Run the application to read from /Connection prefix, you will notice no ssm parameter loaded in the config even anyOtherParam.
After apply fix, you will notice `OracleConnection` and `anyOtherParam` will appear in the dotnet config.
 
## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist 
- [ Y] My code follows the code style of this project
- [ N] My change requires a change to the documentation
- [ N] I have updated the documentation accordingly
- [ Y] I have read the **README** document
- [ N] I have added tests to cover my changes
- [Y ] All new and existing tests passed

## License 
- [ Y] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
