### PR TITLE
Updated Readme to add details for referencing secrets from AWS Secrets Manager from Parameter Store parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,27 @@ public class Program
             .UseStartup<Startup>();
 }
 ```
+It is also possible to load AWS Secrets Manager secrets from Parameter Store parameters. When retrieving a Secrets Manager secret from Parameter Store, the name must begin with the following reserved path: /aws/reference/secretsmanager/`{Secret-Id}`. Below example demonstrates this use case:
+```csharp
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateWebHostBuilder(args).Build().Run();
+    }
 
-Second possibility is to pull configuration from AppConfig. You can easily add this functionality by adding 1 line of code.
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+        WebHost.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration(builder =>
+            {
+                builder.AddSystemsManager("/aws/reference/secretsmanager/SomeSecret");
+            })
+            .UseStartup<Startup>();
+}
+```
+For loading secrets, the library will use `JsonParameterProcessor` to load Key/Value pairs stored in the secret. These Key/Value pairs could be retrieved from the `ConfigurationManager` object. For more details, kindly refer [Referencing AWS Secrets Manager secrets from Parameter Store parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html).
+
+Another possibility is to pull configuration from AppConfig. You can easily add this functionality by adding 1 line of code.
 
 ```csharp
 public class Program
@@ -207,6 +226,8 @@ The AWS credentials used must have access to the `ssm:GetParameters` service ope
 The above policy gives user access to get and use parameters which begin with the specified prefix.
 
 For more details, refer [Restricting access to Systems Manager parameters using IAM policies](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html).
+
+Additionally, for referencing secrets from AWS Secrets Manager from Paramater Store parameters, AWS credentials used must have permissions to access the secret.
 
 ## AppConfig
 If the application reads configuration values from AWS Systems Manager AppConfig, the AWS credentials used must have access to `appconfig:StartConfigurationSession` and `appconfig:GetLatestConfiguration` service operations. Below is an example IAM policy for this action.

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerExtensions.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, AWSOptions awsOptions, bool optional, TimeSpan reloadAfter)
         {
@@ -55,7 +54,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="optional">Whether the AWS Systems Manager Parameters are optional.</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, AWSOptions awsOptions, bool optional)
         {
@@ -74,7 +72,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, AWSOptions awsOptions, TimeSpan reloadAfter)
         {
@@ -91,7 +88,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="path">The path that variable names must start with. The path will be removed from the variable names.</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="awsOptions"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, AWSOptions awsOptions)
         {
@@ -109,7 +105,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="optional">Whether the AWS Systems Manager Parameters are optional.</param>
         /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, bool optional, TimeSpan reloadAfter)
         {
@@ -125,7 +120,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="path">The path that variable names must start with. The path will be removed from the variable names.</param>
         /// <param name="optional">Whether the AWS Systems Manager Parameters are optional.</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, bool optional)
         {
@@ -141,7 +135,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="path">The path that variable names must start with. The path will be removed from the variable names.</param>
         /// <param name="reloadAfter">Initiate reload after TimeSpan</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path, TimeSpan reloadAfter)
         {
@@ -156,7 +149,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="path">The path that variable names must start with. The path will be removed from the variable names.</param>
         /// <exception cref="ArgumentNullException"><see cref="path"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, string path)
         {
@@ -172,7 +164,6 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="configureSource">Configures the source.</param>
         /// <exception cref="ArgumentNullException"><see cref="configureSource"/> cannot be null</exception>
         /// <exception cref="ArgumentNullException"><see cref="configureSource"/>.<see cref="SystemsManagerConfigurationSource.Path"/> cannot be null</exception>
-        /// <exception cref="ArgumentException"><see cref="configureSource"/>.<see cref="SystemsManagerConfigurationSource.Path"/> does not support Secrets Manager prefix (/aws/reference/secretsmanager/)</exception>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder, Action<SystemsManagerConfigurationSource> configureSource)
         {


### PR DESCRIPTION
## Description
Updated Readme to add details for referencing secrets from AWS Secrets Manager from Parameter Store parameters.

## Motivation and Context
Issue: #121

## Testing
Developed ASP.NET Core 6.0 application locally and tested that secrets could be loaded when using this library.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
