### PR TITLE
Support TargetFramework of netstandard2.0 and version bump to 5.0.4.

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,4 +1,12 @@
-﻿### Release 2023-03-21
+﻿### Release 2023-05-30
+* **Amazon.Extensions.Configuration.SystemsManager (5.0.4)**
+   * Support TargetFramework of netstandard2.0.
+
+### Release 2023-05-13
+* **Amazon.Extensions.Configuration.SystemsManager (5.0.3)**
+    * Updated the XML comment documentation and README.md
+
+### Release 2023-03-21
 * **Amazon.Extensions.Configuration.SystemsManager (5.0.2)**
    * Fixed an issue where AppConfig JSON configuration with charset information in ContentType was not being parsed.
 

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,12 +1,4 @@
-﻿### Release 2023-05-30
-* **Amazon.Extensions.Configuration.SystemsManager (5.0.4)**
-   * Support TargetFramework of netstandard2.0.
-
-### Release 2023-05-13
-* **Amazon.Extensions.Configuration.SystemsManager (5.0.3)**
-    * Updated the XML comment documentation and README.md
-
-### Release 2023-03-21
+﻿### Release 2023-03-21
 * **Amazon.Extensions.Configuration.SystemsManager (5.0.2)**
    * Fixed an issue where AppConfig JSON configuration with charset information in ContentType was not being parsed.
 

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>5.0.3</VersionPrefix>
+    <VersionPrefix>5.0.4</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>
     <Product>Amazon.Extensions.Configuration.SystemsManager</Product>
     <Description>.NET Configuration Extensions for AWS Systems Manager</Description>
     <Authors>Amazon Web Services</Authors>
-    <Copyright>2018-2021</Copyright>
+    <Copyright>2018-2023</Copyright>
     <PackageTags>AWS;Amazon;aws-sdk-v3;SimpleSystemsManagement;configuration</PackageTags>
     <PackageProjectUrl>https://github.com/aws/aws-dotnet-extensions-configuration/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -48,6 +48,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.12.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.*" />
+    <PackageReference Include="System.Text.Json" Condition=" '$(TargetFramework)' == 'netstandard2.0' " Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Included netstandard2.0 support for a .NET Framework use-case, see: https://github.com/aws/aws-dotnet-extensions-configuration/pull/150 -->
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>


### PR DESCRIPTION
Update: Support the netstandard2.0 target framework (in addition to the existing ones)

## Description
I have a project where I need to use this library from .NET Framework for backward compatibility purposes. By conditionally referencing the `System.Text.Json` package, it's possible to build the entire solution to target netstandard2.0 and therefore be consumed from .NET Framework.

## Motivation and Context
The netstandard2.0 target framework allows this package to be used by additional .NET runtimes.  In my case, I need to run my solution under .NET Framework for legacy reasons.

The only issue was the `System.Text.Json` package which isn't included in the framework for netstandard2.0, but there is a Microsoft-supplied external package that can be used to support netstandard2.0.  By conditionally including this `PackageReference` it only affects the netstandard2.0 target (keeping the other targets using their internally included packages).

## Testing
Successfully ran the `Amazon.Extensions.Configuration.SystemsManager.Tests` unit test suite.

## Screenshots (if appropriate)
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
