### PR TITLE
fix: Use netstandard2.0-compatible string.Split in DefaultParameterProcessor

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DefaultParameterProcessor.cs
@@ -49,7 +49,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager
             // You can't use other punctuation or special characters to escape items in the list.
             // If you have a parameter value that requires a comma, then use the String type.
             // https://docs.aws.amazon.com/systems-manager/latest/userguide/param-create-cli.html#param-create-cli-stringlist
-            return parameter.Value.Split(",").Select((value, idx) =>
+            return parameter.Value.Split(',').Select((value, idx) =>
                 new KeyValuePair<string, string>($"{GetKey(parameter, path)}:{idx}", value));
         }
 


### PR DESCRIPTION
## Description
Fixes the build after #142 

## Motivation and Context
That PR wasn't rebased on the recent change that added .NET Standard 2.0 to our target frameworks. It used a newer `string.Split` signature that isn't available.

## Testing
Ran unit + integ tests locally

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
