### PR TITLE
Throw exception if duplicate Systems Manager parameter keys (case insensitive) are detected irrespective of whether the parameter is optional or not.

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Amazon.Extensions.Configuration.SystemsManager.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Amazon.Extensions.Configuration.SystemsManager</AssemblyName>
     <RootNamespace>Amazon.Extensions.Configuration.SystemsManager</RootNamespace>
     <OutputType>Library</OutputType>
-    <VersionPrefix>6.1.1</VersionPrefix>
+    <VersionPrefix>6.2.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.Extensions.Configuration.SystemsManager</PackageId>
     <Title>.NET Configuration Extensions for AWS Systems Manager</Title>

--- a/src/Amazon.Extensions.Configuration.SystemsManager/DuplicateParameterException.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/DuplicateParameterException.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+
+namespace Amazon.Extensions.Configuration.SystemsManager
+{
+    /// <summary>
+    /// This exception is thrown when duplicate Systems Manager parameter keys (case insensitive) are 
+    /// detected irrespective of whether the parameter is optional or not.
+    /// <para>
+    /// For example, keys <c>/some-path/some-key</c> and <c>/some-path/SOME-KEY</c> are considered as duplicates.
+    /// </para>
+    /// </summary>
+    public class DuplicateParameterException : ArgumentException
+    {
+        /// <summary>
+        /// Initializes a new instance of DuplicateParameterException.
+        /// </summary>
+        public DuplicateParameterException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of DuplicateParameterException.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public DuplicateParameterException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of DuplicateParameterException.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public DuplicateParameterException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/JsonParameterProcessor.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/JsonParameterProcessor.cs
@@ -40,6 +40,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                 foreach (var keyValue in parameterDictionary)
                 {
                     string key = (!string.IsNullOrEmpty(prefix) ? ConfigurationPath.Combine(prefix, keyValue.Key) : keyValue.Key);
+
+                    // Check for duplicate parameter key.
+                    if (outputDictionary.ContainsKey(key))
+                    {
+                        throw new DuplicateParameterException($"Duplicate parameter '{key}' found. Parameter keys are case-insensitive.");
+                    }
+
                     outputDictionary.Add(key, keyValue.Value);
                 }
             }

--- a/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/SystemsManagerConfigurationProvider.cs
@@ -120,6 +120,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager
                     OnReload();
                 }
             }
+            catch (DuplicateParameterException) // Throw duplicate parameter exception irrespective of whether parameter is optional or not.
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 if (Source.Optional) return;

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/DefaultParameterProcessorTests.cs
@@ -71,5 +71,31 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
             Assert.All(data, item => Assert.Equal(item.Value, item.Key));
         }
+
+        [Fact]
+        public void DuplicateSimpleParametersTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/start/path/p1", Value = "p1:1"},
+                new Parameter {Name = "/start/path/P1", Value = "p1:2"}
+            };
+
+            const string path = "/start/path";
+            Assert.Throws<DuplicateParameterException>(() => _parameterProcessor.ProcessParameters(parameters, path));
+        }
+
+        [Fact]
+        public void DuplicateStringListParametersTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/string-list/multiple", Value = "p1,p2,p3", Type = ParameterType.StringList},
+                new Parameter {Name = "/string-list/MULTIPLE", Value = "p3,p5,p6", Type = ParameterType.StringList}
+            };
+
+            const string path = "/string-list";
+            Assert.Throws<DuplicateParameterException>(() => _parameterProcessor.ProcessParameters(parameters, path));
+        }
     }
 }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonParameterProcessorTests.cs
@@ -44,5 +44,19 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
             Assert.All(expected, item => Assert.Equal(item.Value, data[item.Key]));
         }
+
+        [Fact]
+        public void DuplicateParametersTest()
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter {Name = "/p1", Value = "{\"p1\": \"p1\"}"},
+                new Parameter {Name = "p2", Value = "{\"p2\": \"p2\"}"},
+                new Parameter {Name = "p1", Value = "{\"P1\": \"p1-1\"}"},
+            };
+
+            const string path = "/";
+            Assert.Throws<DuplicateParameterException>(() => _parameterProcessor.ProcessParameters(parameters, path));
+        }
     }
 }


### PR DESCRIPTION
## Description
Throw exception if duplicate Systems Manager parameter keys (case insensitive) are detected irrespective of whether the parameter is optional or not.

Kindly note that if keys are duplicated, .NET framework raises a generic `System.ArgumentException` with a message. We cannot use it since this exception could be thrown for other scenarios. Hence, added a new bare minimal `DuplicateParameterException` class.

## Motivation and Context
Issue #146 

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
