### PR TITLE
chore: add workflow to check if change file is included in a PR

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -1,0 +1,30 @@
+name: Change File Included in PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  check-files-in-directory:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
+    name: Change File Included in PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v3
+
+      - name: Get List of Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf #v45
+
+      - name: Check for Change File(s) in .autover/changes/
+        run: |
+          DIRECTORY=".autover/changes/"
+          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+            echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
+          else
+            echo "❌ No change files in '$DIRECTORY' are included in this PR."
+            echo "Refer to the 'Adding a change file to your contribution branch' section of https://github.com/aws/aws-dotnet-extensions-configuration/blob/master/CONTRIBUTING.md"
+            exit 1
+          fi


### PR DESCRIPTION
*Description of changes:*
The PR adds a new Workflow that checks if a PR contains a change file. If a change file is not required, PRs should add the label `Release Not Needed`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
