### PR TITLE
Added support for AppConfig Feature Flag profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,51 @@ namespace CustomParameterProcessorExample
 }
 ```
 
+### Simple AppConfig FeatureFlag Sample
+```csharp
+//
+// AppConfigFeatureFlag.cs
+//
+public class AppConfigFeatureFlag
+{
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+}
+
+//
+// Program.cs
+//
+
+// Map feature flag configuration 
+builder.Services.Configure<Dictionary<string, AppConfigFeatureFlag>>(builder.Configuration.GetSection("FeatureFlags"));
+
+// Add AppConfig configuration source
+var awsAppConfigClient = new AmazonAppConfigDataClient();
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .AddAppConfig(new AppConfigConfigurationSource()
+    {
+        ApplicationId = "application",
+        EnvironmentId = "Default",
+        ConfigProfileId = "my-appconfig-feature-profile",
+        AwsOptions = new AWSOptions(),
+        ReloadAfter = new TimeSpan(0, 0, 30),
+        WrapperNodeName = "FeatureFlags" // Nest AppConfig FeatureFlag data under this node
+    });
+
+//
+// TestApi.cs
+//
+public class TestApi : ITestApi
+{
+    private readonly IOptionsMonitor<Dictionary<string, AppConfigFeatureFlag>> _FeatureFlags;
+    public TestApi(IOptionsMonitor<Dictionary<string, AppConfigFeatureFlag>> featureFlags)
+    {
+        _FeatureFlags = featureFlags;
+    }
+}
+```
+
 For more complete examples, take a look at sample projects available in [samples directory](https://github.com/aws/aws-dotnet-extensions-configuration/tree/master/samples).
 
 # Configuring Systems Manager Client

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigConfigurationSource.cs
@@ -51,6 +51,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager.AppConfig
 
         /// <inheritdoc />
         public TimeSpan? ReloadAfter { get; set; }
+        
+        /// <summary>
+        /// Name of the node to wrap the configuration data in.
+        /// </summary>
+        public string WrapperNodeName { get; set; }
 
         /// <summary>
         /// Indicates to use configured lambda extension HTTP client to retrieve AppConfig data.

--- a/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/AppConfig/AppConfigExtensions.cs
@@ -238,7 +238,8 @@ namespace Microsoft.Extensions.Configuration
             string configProfileId,
             AWSOptions awsOptions = null,
             bool optional = false,
-            TimeSpan? reloadAfter = null
+            TimeSpan? reloadAfter = null,
+            string wrapperNodeName = null
         )
         {
             return new AppConfigConfigurationSource
@@ -248,7 +249,8 @@ namespace Microsoft.Extensions.Configuration
                 ConfigProfileId = configProfileId,
                 AwsOptions = awsOptions,
                 Optional = optional,
-                ReloadAfter = reloadAfter
+                ReloadAfter = reloadAfter,
+                WrapperNodeName = wrapperNodeName
             };
         }
     }

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Extensions.Configuration.SystemsManager.AppConfig;
+using Amazon.Extensions.NETCore.Setup;
+using Xunit;
+
+namespace Amazon.Extensions.Configuration.SystemsManager.Tests
+{
+    public class AppConfigProcessorTests
+    {
+        [Fact]
+        public async Task AddWrapperNode_WithWrapperNodeName_WrapsConfigurationCorrectly()
+        {
+            // Arrange
+            var source = new AppConfigConfigurationSource
+            {
+                ApplicationId = "appId",
+                EnvironmentId = "envId",
+                ConfigProfileId = "profileId",
+                WrapperNodeName = "FeatureFlags",
+                AwsOptions = new AWSOptions()
+            };
+            
+            var processor = new AppConfigProcessor(source);
+            var inputJson = "{\"test-flag-1\":{\"enabled\":false},\"test-flag-2\":{\"enabled\":true}}";
+            using var inputStream = new MemoryStream(Encoding.UTF8.GetBytes(inputJson));
+            using var outputStream = new MemoryStream();
+            
+            // Act
+            await InvokeAddWrapperNode(processor, inputStream, outputStream);
+            
+            // Assert
+            string resultJson;
+            using (var reader = new StreamReader(outputStream))
+            {
+                resultJson = reader.ReadToEnd();
+            }
+            
+            var expectedJson = "{\"FeatureFlags\":{\"test-flag-1\":{\"enabled\":false},\"test-flag-2\":{\"enabled\":true}}}";
+            Assert.Equal(expectedJson, resultJson);
+        }
+        
+        // Helper method to invoke the private AddWrapperNode method using reflection
+        private async Task InvokeAddWrapperNode(AppConfigProcessor processor, Stream configuration, Stream wrappedConfig)
+        {
+            var method = typeof(AppConfigProcessor).GetMethod("AddWrapperNodeAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            await (Task)method.Invoke(processor, new object[] { configuration, wrappedConfig });
+        }
+    }
+}


### PR DESCRIPTION
Added support for AppConfig Feature Flag profiles by allowing the consumer to nest the resulting JSON in a named parent node.

## Description
This aims to allow consumers to inject feature flags into their application. The user cannot control the schema for AppConfig Feature Flag profiles because they are controlled by AWS. The JSON format is like this:

```
{"test-flag-1":{"enabled":false},"test-flag-2":{"enabled":true}}
```

This is not friendly with the .NET builder.Configuration system because there is no named wrapper node around the list of feature flags. The result is that each flag is nested directly under the root of the configuration hierarchy.

This update allows the consumer to pass in the name of a wrapper node to nest the AppConfig JSON inside of by using the extension method for AppConfig registration:

```csharp
    builder.Configuration.AddAppConfig(new AppConfigConfigurationSource()
    {
        ApplicationId = "application",
        EnvironmentId = "Default",
        ConfigProfileId = "my-appconfig-feature-profile",
        AwsOptions = new AWSOptions(),
        ReloadAfter = new TimeSpan(0, 0, 30),
        WrapperNodeName = "FeatureFlags"
    })
```

And then read the values from that configuration profile, by deserializing the JSON into a dictionary of feature flag class instances:

```csharp
builder.Services.Configure<Dictionary<string, AppConfigFeatureFlag>(builder.Configuration.GetSection("FeatureFlags"));
```

## Motivation and Context
The end goal is to allow the consumer to inject feature flags into their controllers and minimal API class constructors, such as in the following:

```csharp
MyConstructor(IOptionsMonitor<Dictionary<string, AppConfigFeatureFlag>> featureFlags)
```

This addresses the following feature request:
https://github.com/aws/aws-dotnet-extensions-configuration/issues/228


## Testing
Initial testing was done by creating a unit test. Follow-up testing was done by integrating the library into an application that consumed both configuration profiles and feature flag profiles. The tests validated both profiles loaded correctly and were injected into the services DI container.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
