### PR TITLE
Fix broken test in CI

### DIFF
--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/SystemsManagerProcessorTests.cs
@@ -133,28 +133,6 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
         #endregion
 
-        #region GetParametersByNamesAsync Batching Tests
-        // Note: These tests verify batching behavior indirectly through empty collection handling
-        // Full batching tests with API call counting require integration testing or refactoring
-        // the SystemsManagerProcessor to accept an injectable client factory
-
-        [Fact]
-        public async Task GetDataAsync_WithParameterNames_EmptyCollection_ReturnsEmptyDictionary()
-        {
-            // Arrange
-            var source = CreateTestSource("/myapp");
-            source.ParameterNames = new List<string>();
-            var processor = new SystemsManagerProcessor(source);
-
-            // Act
-            var result = await processor.GetDataAsync();
-
-            // Assert
-            Assert.Empty(result);
-        }
-
-        #endregion
-
         #region Parameter Not Found Handling Tests
 
         [Fact]


### PR DESCRIPTION
## Description
Using AI to help generate tests created a test in the unit test package that makes real AWS service calls. This fails in the CI system because it can't acquire AWS credentials to run the test. Removed the test and the integ tests that were added for the feature going out in the CI system cover make the real service requests.

## Motivation and Context
Fix the blocked CI pipeline

