### PR TITLE
Bug Fix: Throw JsonException for root-level JSON primitives - Fix #247

### DIFF
--- a/.autover/changes/69908383-469a-4bc5-a2e6-c4079a4274f3.json
+++ b/.autover/changes/69908383-469a-4bc5-a2e6-c4079a4274f3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.Configuration.SystemsManager",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed ArgumentNullException in JsonOrStringParameterProcessor when a parameter value is a JSON primitive (true, false, number, null). JsonConfigurationParser.Parse() now throws JsonException for root-level primitives, correctly activating the string fallback."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
@@ -36,6 +36,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
         {
             using (var doc = JsonDocument.Parse(input))
             {
+                if (doc.RootElement.ValueKind != JsonValueKind.Object && doc.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    throw new JsonException($"The root JSON element must be an object or array, but was '{doc.RootElement.ValueKind}'. A JSON primitive at the root cannot be represented as a configuration key-value structure.");
+                }
+
                 var parser = new JsonConfigurationParser();
                 parser.VisitElement(doc.RootElement);
                 return parser._data;
@@ -46,6 +51,11 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
         {
             using (var doc = JsonDocument.Parse(input))
             {
+                if (doc.RootElement.ValueKind != JsonValueKind.Object && doc.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    throw new JsonException($"The root JSON element must be an object or array, but was '{doc.RootElement.ValueKind}'. A JSON primitive at the root cannot be represented as a configuration key-value structure.");
+                }
+
                 var parser = new JsonConfigurationParser();
                 parser.VisitElement(doc.RootElement);
                 return parser._data;

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonOrStringParameterProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/JsonOrStringParameterProcessorTests.cs
@@ -119,5 +119,32 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             Assert.True(result.ContainsKey("stringList:1"));
             Assert.Equal("value2", result["stringList:1"]);
         }
+
+        /// <summary>
+        /// Regression test for: when a parameter value is a JSON primitive (boolean, number, string, null),
+        /// JsonDocument.Parse() succeeds (primitives are valid JSON) but JsonConfigurationParser previously
+        /// crashed with ArgumentNullException because _currentPath was null at the root level.
+        /// Since ArgumentNullException is not JsonException, the fallback to string processing was never reached.
+        /// The fix makes JsonConfigurationParser.Parse() throw JsonException for root primitives, so the
+        /// fallback correctly treats the value as a plain string — matching DefaultParameterProcessor behaviour.
+        /// </summary>
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        [InlineData("42")]
+        [InlineData("3.14")]
+        [InlineData("null")]
+        public void ProcessParameters_FallsBackToString_WhenValueIsJsonPrimitive(string primitiveValue)
+        {
+            var parameters = new List<Parameter>
+            {
+                new Parameter() { Name = "/test/value", Type = ParameterType.String, Value = primitiveValue }
+            };
+            var result = _parameterProcessor.ProcessParameters(parameters, "/test");
+
+            Assert.Single(result);
+            Assert.True(result.ContainsKey("value"));
+            Assert.Equal(primitiveValue, result["value"]);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`JsonOrStringParameterProcessor` crashes with `ArgumentNullException` when a parameter value is a JSON primitive (`true`, `false`, a number, or `null`). The fix adds a guard in `JsonConfigurationParser.Parse()` to throw `JsonException` for root-level primitives, which correctly activates the existing string fallback in `JsonOrStringParameterProcessor`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
A bug was reported for when using `JsonOrStringParameterProcessor` with a parameter like `/some/path/value = true`, the processor is supposed to fall back to treating the value as a plain string (since a primitive has no JSON structure to expand). Instead it crashes with `ArgumentNullException`.

Root cause: `JsonDocument.Parse("true")` succeeds (primitives are valid JSON per spec), so no `JsonException` is thrown. Execution then reaches `JsonConfigurationParser.VisitPrimitive()`, which uses `_currentPath` as a dictionary key — but `_currentPath` is `null` at the root level because `EnterContext()` is never called for the root element. The resulting `ArgumentNullException` is not caught by `JsonOrStringParameterProcessor`'s `catch (JsonException)` block, so it escapes and crashes the caller. This makes `JsonOrStringParameterProcessor` incompatible with parameters whose values are JSON primitives, breaking its advertised backwards-compatibility with `DefaultParameterProcessor`.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added a `[Theory]` regression test `ProcessParameters_FallsBackToString_WhenValueIsJsonPrimitive` in `JsonOrStringParameterProcessorTests` covering all five primitive types: `true`, `false`, `42`, `3.14`, `null`.
- All 131 unit tests pass.
- Verified the original `ArgumentNullException` crash is reproducible and disappears after adding the fix.


## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

__No breaking changes.__ `JsonConfigurationParser` is an `internal` class; its `Parse()` methods are not part of the public API. The change in behaviour (throwing `JsonException` instead of `ArgumentNullException` for root primitives) is only observable within the library itself, and the `JsonException` is immediately caught and handled by `JsonOrStringParameterProcessor`'s existing fallback. All previously working scenarios (JSON objects, JSON arrays, plain strings, string lists) are completely unaffected.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement