### PR TITLE
Parse empty JSON objects and array as Microsoft's JsonConfigurationFileParser

### DIFF
--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
@@ -59,12 +59,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                 case JsonValueKind.Undefined:
                     break;
                 case JsonValueKind.Object:
-                    foreach (var property in element.EnumerateObject())
-                    {
-                        EnterContext(property.Name);
-                        VisitElement(property.Value);
-                        ExitContext();
-                    }
+                    VisitObject(element);
                     break;
                 case JsonValueKind.Array:
                     VisitArray(element);
@@ -82,8 +77,31 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
 
         }
 
+        private void VisitObject(JsonElement element)
+        {
+            var isEmpty = !element.EnumerateObject().Any();
+            if (isEmpty)
+            {
+                VisitEmpty();
+                return;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                EnterContext(property.Name);
+                VisitElement(property.Value);
+                ExitContext();
+            }
+        }
+
         private void VisitArray(JsonElement array)
         {
+            if (array.GetArrayLength() is 0)
+            {
+                VisitEmpty();
+                return;
+            }
+
             int index = 0;
             foreach (var item in array.EnumerateArray())
             {
@@ -98,6 +116,18 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
         private void VisitNull()
         {
             var key = _currentPath;
+            _data[key] = null;
+        }
+
+        private void VisitEmpty()
+        {
+            var key = _currentPath;
+
+            if (key is null)
+            {
+                return;
+            }
+
             _data[key] = null;
         }
 

--- a/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
+++ b/src/Amazon.Extensions.Configuration.SystemsManager/Internal/JsonConfigurationParser.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 
@@ -74,34 +73,25 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
                     VisitNull();
                     break;
             }
-
         }
 
         private void VisitObject(JsonElement element)
         {
-            var isEmpty = !element.EnumerateObject().Any();
-            if (isEmpty)
-            {
-                VisitEmpty();
-                return;
-            }
+            var isEmpty = true;
 
             foreach (var property in element.EnumerateObject())
             {
+                isEmpty = false;
                 EnterContext(property.Name);
                 VisitElement(property.Value);
                 ExitContext();
             }
+
+            SetIfEmpty(isEmpty, null);
         }
 
         private void VisitArray(JsonElement array)
         {
-            if (array.GetArrayLength() is 0)
-            {
-                VisitEmpty();
-                return;
-            }
-
             int index = 0;
             foreach (var item in array.EnumerateArray())
             {
@@ -111,6 +101,8 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
 
                 index++;
             }
+
+            SetIfEmpty(isEmpty: index == 0, string.Empty);
         }
 
         private void VisitNull()
@@ -119,16 +111,13 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Internal
             _data[key] = null;
         }
 
-        private void VisitEmpty()
+        private void SetIfEmpty(bool isEmpty, string value)
         {
             var key = _currentPath;
-
-            if (key is null)
+            if (isEmpty && key != null)
             {
-                return;
+                _data[key] = value;
             }
-
-            _data[key] = null;
         }
 
         private void VisitPrimitive(JsonElement data)

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
@@ -29,9 +29,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig("application/json", stream);
-            
+
             Assert.Equal("value1", result["key1"]);
             Assert.Equal("value2", result["key2"]);
         }
@@ -41,9 +41,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig("application/octet-stream", stream);
-            
+
             Assert.Equal("value1", result["key1"]);
             Assert.Equal("value2", result["key2"]);
         }
@@ -53,9 +53,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig("application/json; charset=utf-8", stream);
-            
+
             Assert.Equal("value1", result["key1"]);
             Assert.Equal("value2", result["key2"]);
         }
@@ -65,9 +65,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig("application/unknown", stream);
-            
+
             Assert.Equal("value1", result["key1"]);
             Assert.Equal("value2", result["key2"]);
         }
@@ -77,9 +77,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig(null, stream);
-            
+
             Assert.Equal("value1", result["key1"]);
             Assert.Equal("value2", result["key2"]);
         }
@@ -89,9 +89,9 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{\"section1\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"section2\":{\"key3\":\"value3\"}}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
+
             var result = AppConfigProcessor.ParseConfig("application/octet-stream", stream);
-            
+
             Assert.Equal("value1", result["section1:key1"]);
             Assert.Equal("value2", result["section1:key2"]);
             Assert.Equal("value3", result["section2:key3"]);
@@ -102,10 +102,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var invalidJsonContent = "{ invalid json content }";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJsonContent));
-            
-            var exception = Assert.Throws<InvalidOperationException>(() => 
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
                 AppConfigProcessor.ParseConfig("application/json", stream));
-            
+
             Assert.Contains("Failed to parse AppConfig content as JSON", exception.Message);
             Assert.Contains("Content-Type was 'application/json'", exception.Message);
         }
@@ -115,10 +115,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var invalidJsonContent = "not json at all";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJsonContent));
-            
-            var exception = Assert.Throws<InvalidOperationException>(() => 
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
                 AppConfigProcessor.ParseConfig("application/octet-stream", stream));
-            
+
             Assert.Contains("Failed to parse AppConfig content as JSON", exception.Message);
             Assert.Contains("Content-Type was 'application/octet-stream'", exception.Message);
         }
@@ -128,21 +128,10 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
         {
             var jsonContent = "{}";
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            
-            var result = AppConfigProcessor.ParseConfig("application/json", stream);
-            
-            Assert.Empty(result);
-        }
 
-        [Fact]
-        public void ParseConfig_EmptyStream_ThrowsInvalidOperationException()
-        {
-            using var stream = new MemoryStream();
-            
-            var exception = Assert.Throws<InvalidOperationException>(() => 
-                AppConfigProcessor.ParseConfig("application/json", stream));
-            
-            Assert.Contains("Failed to parse AppConfig content as JSON", exception.Message);
+            var result = AppConfigProcessor.ParseConfig("application/json", stream);
+
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -155,6 +144,18 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
 
             Assert.Empty(result);
         }
+
+        [Fact]
+        public void ParseConfig_EmptyStream_ThrowsInvalidOperationException()
+        {
+            using var stream = new MemoryStream();
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                AppConfigProcessor.ParseConfig("application/json", stream));
+
+            Assert.Contains("Failed to parse AppConfig content as JSON", exception.Message);
+        }
+
 
         [Fact]
         public void ParseConfig_JsonWithEmptyArrayAndObjectProps_ReturnsNullValuesForThoseProps()
@@ -172,7 +173,7 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             Assert.Equivalent(
                 new Dictionary<string, string>
                 {
-                    { "empty_array", null },
+                    { "empty_array", string.Empty},
                     { "empty_object", null }
                 },
                 result);

--- a/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
+++ b/test/Amazon.Extensions.Configuration.SystemsManager.Tests/AppConfigProcessorTests.cs
@@ -144,5 +144,38 @@ namespace Amazon.Extensions.Configuration.SystemsManager.Tests
             
             Assert.Contains("Failed to parse AppConfig content as JSON", exception.Message);
         }
+
+        [Fact]
+        public void ParseConfig_EmptyArray_ReturnsEmptyDictionary()
+        {
+            var jsonContent = "[]";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
+
+            var result = AppConfigProcessor.ParseConfig("application/json", stream);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParseConfig_JsonWithEmptyArrayAndObjectProps_ReturnsNullValuesForThoseProps()
+        {
+            var jsonContent = """
+                {
+                    "empty_array": [],
+                    "empty_object": {}
+                }
+                """;
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
+
+            var result = AppConfigProcessor.ParseConfig("application/json", stream);
+
+            Assert.Equivalent(
+                new Dictionary<string, string>
+                {
+                    { "empty_array", null },
+                    { "empty_object", null }
+                },
+                result);
+        }
     }
 }


### PR DESCRIPTION
## Description
Refactored JsonConfigurationParser to explicitly handle empty objects and arrays the same way as [JsonConfigurationFileParser.cs](https://source.dot.net/#Microsoft.Extensions.Configuration.Json/JsonConfigurationFileParser.cs,5f36e46099a6acaf) does. Added SetIfEmpty method. Updated tests to verify correct handling of empty arrays and objects in JSON input.

## Motivation and Context
Handle empty JSON object and empty JSON array the same way as [JsonConfigurationFileParser.cs](https://source.dot.net/#Microsoft.Extensions.Configuration.Json/JsonConfigurationFileParser.cs,5f36e46099a6acaf) does.

## Testing
Functionality is covered by unit tests.

## Breaking Changes Summary

### What Changed
The `JsonConfigurationParser` now explicitly handles empty JSON objects and arrays:
- **Empty arrays** (`[]`) are parsed as an empty string (`string.Empty`)
- **Empty objects** (`{}`) are parsed as `null`

This aligns the behavior with Microsoft's standard `JsonConfigurationFileParser`.

### Impact on Customers
**This is a breaking change** because applications relying on the previous behavior will see different values:

| Scenario | Old Behavior | New Behavior | Customer Impact |
|----------|---|---|---|
| `"empty_array": []` | Ignored/skipped | Returns `string.Empty` | Configuration keys may now exist where they didn't before |
| `"empty_object": {}` | Ignored/skipped | Returns `null` | Configuration keys with null values instead of missing |

### Why a Breaking Change Was Needed
The existing implementation silently ignored empty arrays and objects. This is inconsistent with:
1. **Microsoft's standard library** (`JsonConfigurationFileParser`)
2. **Expected behavior** - empty containers should have a representable value in the configuration dictionary


## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-dotnet-extensions-configuration/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement







